### PR TITLE
[Fix #15] Fix Java 7 compatibility issue

### DIFF
--- a/spatial-utilities/src/main/java/org/orbisgis/sputilities/SFSUtilities.java
+++ b/spatial-utilities/src/main/java/org/orbisgis/sputilities/SFSUtilities.java
@@ -90,7 +90,7 @@ public class SFSUtilities {
      * @return Wrapped DataSource, with spatial methods
      */
     public static Connection wrapConnection(Connection connection) {
-        return new ConnectionWrapper(connection,null);
+        return new ConnectionWrapper(connection);
     }
 
     /**

--- a/spatial-utilities/src/main/java/org/orbisgis/sputilities/wrapper/ConnectionWrapper.java
+++ b/spatial-utilities/src/main/java/org/orbisgis/sputilities/wrapper/ConnectionWrapper.java
@@ -17,17 +17,16 @@ import java.sql.Statement;
 import java.sql.Struct;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.Executor;
 
 /**
  * @author Nicolas Fortin
  */
 public class ConnectionWrapper implements Connection {
     private Connection connection;
-    private DataSourceWrapper dataSource;
 
-    public ConnectionWrapper(Connection connection, DataSourceWrapper dataSource) {
+    public ConnectionWrapper(Connection connection) {
         this.connection = connection;
-        this.dataSource = dataSource;
     }
 
     @Override
@@ -263,6 +262,31 @@ public class ConnectionWrapper implements Connection {
     @Override
     public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
         return connection.createStruct(typeName, attributes);
+    }
+
+    // @Override -- Commented out for Java 6 compatibility.
+    public void setSchema(String schema) throws SQLException {
+        throw new UnsupportedOperationException("This Java 7 method is not yet supported.");
+    }
+
+    // @Override -- Commented out for Java 6 compatibility.
+    public String getSchema() throws SQLException {
+        throw new UnsupportedOperationException("This Java 7 method is not yet supported.");
+    }
+
+    // @Override -- Commented out for Java 6 compatibility.
+    public void abort(Executor executor) throws SQLException {
+        throw new UnsupportedOperationException("This Java 7 method is not yet supported.");
+    }
+
+    // @Override -- Commented out for Java 6 compatibility.
+    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+        throw new UnsupportedOperationException("This Java 7 method is not yet supported.");
+    }
+
+    // @Override -- Commented out for Java 6 compatibility.
+    public int getNetworkTimeout() throws SQLException {
+        throw new UnsupportedOperationException("This Java 7 method is not yet supported.");
     }
 
     @Override

--- a/spatial-utilities/src/main/java/org/orbisgis/sputilities/wrapper/DataSourceWrapper.java
+++ b/spatial-utilities/src/main/java/org/orbisgis/sputilities/wrapper/DataSourceWrapper.java
@@ -4,6 +4,8 @@ import javax.sql.DataSource;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
 
 /**
  * Entry point for spatial wrapper of SQL Interfaces.
@@ -18,12 +20,12 @@ public class DataSourceWrapper implements DataSource {
 
     @Override
     public Connection getConnection() throws SQLException {
-        return new ConnectionWrapper(dataSource.getConnection(), this);
+        return new ConnectionWrapper(dataSource.getConnection());
     }
 
     @Override
     public Connection getConnection(String username, String password) throws SQLException {
-        return new ConnectionWrapper(dataSource.getConnection(username, password),this);
+        return new ConnectionWrapper(dataSource.getConnection(username, password));
     }
 
     @Override
@@ -44,6 +46,11 @@ public class DataSourceWrapper implements DataSource {
     @Override
     public int getLoginTimeout() throws SQLException {
         return dataSource.getLoginTimeout();
+    }
+
+    // @Override -- Commented out for Java 6 compatibility.
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new UnsupportedOperationException("This Java 7 method is not yet supported.");
     }
 
     @Override

--- a/spatial-utilities/src/main/java/org/orbisgis/sputilities/wrapper/ResultSetWrapper.java
+++ b/spatial-utilities/src/main/java/org/orbisgis/sputilities/wrapper/ResultSetWrapper.java
@@ -969,6 +969,16 @@ public class ResultSetWrapper implements ResultSet {
         resultSet.updateNClob(columnLabel, reader);
     }
 
+    // @Override -- Commented out for Java 6 compatibility.
+    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+        throw new UnsupportedOperationException("This Java 7 method is not yet supported.");
+    }
+
+    // @Override -- Commented out for Java 6 compatibility.
+    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+        throw new UnsupportedOperationException("This Java 7 method is not yet supported.");
+    }
+
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         if(iface.isAssignableFrom(SpatialResultSetImpl.class)) {

--- a/spatial-utilities/src/main/java/org/orbisgis/sputilities/wrapper/StatementWrapper.java
+++ b/spatial-utilities/src/main/java/org/orbisgis/sputilities/wrapper/StatementWrapper.java
@@ -218,6 +218,16 @@ public class StatementWrapper implements Statement {
         return statement.isPoolable();
     }
 
+    // @Override -- Commented out for Java 6 compatibility.
+    public void closeOnCompletion() throws SQLException {
+        throw new UnsupportedOperationException("This Java 7 method is not yet supported.");
+    }
+
+    // @Override -- Commented out for Java 6 compatibility.
+    public boolean isCloseOnCompletion() throws SQLException {
+        throw new UnsupportedOperationException("This Java 7 method is not yet supported.");
+    }
+
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         return statement.unwrap(iface);


### PR DESCRIPTION
For now, all the newly added Java 7 methods are implemented by throwing
an UnsupportedOperationException. This allows us to keep Java 6
compatibility.

See also 6b10b62ad77edcd3491d972179f0a47e08002982 which we should use
once we abandon Java 6.

Fixes #15.
