### PR TITLE
Add a new signature to SHPRead

### DIFF
--- a/h2drivers/src/main/java/org/h2gis/drivers/shp/SHPRead.java
+++ b/h2drivers/src/main/java/org/h2gis/drivers/shp/SHPRead.java
@@ -62,4 +62,18 @@ public class SHPRead  extends AbstractFunction implements ScalarFunction {
         SHPDriverFunction shpDriverFunction = new SHPDriverFunction();
         shpDriverFunction.importFile(connection, tableReference, new File(fileName), new EmptyProgressVisitor());
     }
+
+    /**
+     * Copy data from Shape File into a new table in specified connection.
+     * The newly created table is given the same name as the filename
+     * without the ".shp" extension. If such a table already exists, an
+     * exception is thrown.
+     *
+     * @param connection Active connection
+     * @param fileName   File path of the SHP file
+     */
+    public static void readShape(Connection connection, String fileName) throws IOException, SQLException {
+        final String name = new File(fileName).getName();
+        readShape(connection, fileName, name.substring(0, name.lastIndexOf(".")));
+    }
 }

--- a/h2drivers/src/test/java/org/h2gis/drivers/shp/SHPImportExportTest.java
+++ b/h2drivers/src/test/java/org/h2gis/drivers/shp/SHPImportExportTest.java
@@ -120,7 +120,23 @@ public class SHPImportExportTest {
     public void copySHPTest() throws SQLException {
         Statement st = connection.createStatement();
         st.execute("DROP TABLE IF EXISTS WATERNETWORK");
-        st.execute("CALL SHPRead("+StringUtils.quoteStringSQL(SHPEngineTest.class.getResource("waternetwork.shp").getPath())+", 'WATERNETWORK');");
+        final String path = StringUtils.quoteStringSQL(SHPEngineTest.class.getResource("waternetwork.shp").getPath());
+        st.execute("CALL SHPRead(" + path + ", 'WATERNETWORK');");
+        checkSHPReadResult(st);
+    }
+
+
+    @Test
+    public void copySHPTestAutomaticTableName() throws SQLException {
+        Statement st = connection.createStatement();
+        st.execute("DROP TABLE IF EXISTS WATERNETWORK");
+        final String path = StringUtils.quoteStringSQL(SHPEngineTest.class.getResource("waternetwork.shp").getPath());
+        // No table name is specified:
+        st.execute("CALL SHPRead(" + path + ");");
+        checkSHPReadResult(st);
+    }
+
+    private void checkSHPReadResult(Statement st) throws SQLException {
         // Query declared Table columns
         ResultSet rs = st.executeQuery("SELECT * FROM INFORMATION_SCHEMA.COLUMNS where TABLE_NAME = 'WATERNETWORK'");
         assertTrue(rs.next());


### PR DESCRIPTION
This allows the user to use the following syntax:

``` mysql
CALL SHPREAD('/home/user/myshapefile.shp');
```

The newly created table is called `myshapefile`.

This fixes the issue described by @ebocher in #8.
