### PR TITLE
Add ST_MakePoint

### DIFF
--- a/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/CreateSpatialExtension.java
+++ b/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/CreateSpatialExtension.java
@@ -28,12 +28,14 @@ package org.h2gis.h2spatialext;
 import org.h2gis.drivers.DriverManager;
 import org.h2gis.drivers.dbf.DBFRead;
 import org.h2gis.drivers.dbf.DBFWrite;
+import org.h2gis.drivers.gpx.GPXRead;
 import org.h2gis.drivers.shp.SHPRead;
 import org.h2gis.drivers.shp.SHPWrite;
 import org.h2gis.h2spatialapi.Function;
 import org.h2gis.h2spatialext.function.spatial.affine_transformations.ST_Rotate;
 import org.h2gis.h2spatialext.function.spatial.affine_transformations.ST_Scale;
 import org.h2gis.h2spatialext.function.spatial.convert.*;
+import org.h2gis.h2spatialext.function.spatial.create.ST_MakePoint;
 import org.h2gis.h2spatialext.function.spatial.distance.ST_ClosestCoordinate;
 import org.h2gis.h2spatialext.function.spatial.distance.ST_ClosestPoint;
 import org.h2gis.h2spatialext.function.spatial.distance.ST_FurthestCoordinate;
@@ -47,7 +49,6 @@ import org.h2gis.h2spatialext.function.spatial.properties.*;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
-import org.h2gis.drivers.gpx.GPXRead;
 
 /**
  * Registers the SQL functions contained in h2spatial-ext.
@@ -75,6 +76,7 @@ public class CreateSpatialExtension {
                 new ST_IsRectangle(),
                 new ST_IsValid(),
                 new ST_LocateAlong(),
+                new ST_MakePoint(),
                 new ST_PointsToLine(),
                 new ST_Rotate(),
                 new ST_Scale(),

--- a/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/function/spatial/create/ST_MakePoint.java
+++ b/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/function/spatial/create/ST_MakePoint.java
@@ -1,0 +1,75 @@
+/**
+ * h2spatial is a library that brings spatial support to the H2 Java database.
+ *
+ * h2spatial is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+ * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+ *
+ * Copyright (C) 2007-2012 IRSTV (FR CNRS 2488)
+ *
+ * h2patial is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * h2spatial is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * h2spatial. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+
+package org.h2gis.h2spatialext.function.spatial.create;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+import org.h2gis.h2spatialapi.DeterministicScalarFunction;
+
+import java.sql.SQLException;
+
+/**
+ * ST_MakePoint constructs POINT from two or three doubles.
+ *
+ * @author Adam Gouge
+ */
+public class ST_MakePoint extends DeterministicScalarFunction {
+
+    private static final GeometryFactory GF = new GeometryFactory();
+
+    public ST_MakePoint() {
+        addProperty(PROP_REMARKS, "Constructs POINT from two or three doubles");
+    }
+
+    @Override
+    public String getJavaStaticMethod() {
+        return "createPoint";
+    }
+
+    /**
+     * Constructs POINT from two doubles.
+     *
+     * @param x X-coordinate
+     * @param y Y-coordinate
+     * @return The POINT constructed from the given coordinatesk
+     */
+    public static Point createPoint(double x, double y) throws SQLException {
+        return createPoint(x, y, Coordinate.NULL_ORDINATE);
+    }
+
+    /**
+     * Constructs POINT from three doubles.
+     *
+     * @param x X-coordinate
+     * @param y Y-coordinate
+     * @param z Z-coordinate
+     * @return The POINT constructed from the given coordinates
+     */
+    public static Point createPoint(double x, double y, double z) throws SQLException {
+        return GF.createPoint(new Coordinate(x, y, z));
+    }
+}

--- a/h2spatial-ext/src/test/java/org/h2gis/h2spatialext/SpatialFunctionTest.java
+++ b/h2spatial-ext/src/test/java/org/h2gis/h2spatialext/SpatialFunctionTest.java
@@ -472,6 +472,19 @@ public class SpatialFunctionTest {
     }
 
     @Test
+    public void test_ST_MakePoint() throws Exception {
+        Statement st = connection.createStatement();
+        ResultSet rs = st.executeQuery("SELECT ST_MakePoint(1.4, -3.7), " +
+                "ST_MakePoint(1.4, -3.7, 6.2);");
+        assertTrue(rs.next());
+        assertEquals(WKT_READER.read("POINT(1.4 -3.7)"), rs.getObject(1));
+        assertEquals(WKT_READER.read("POINT(1.4 -3.7 6.2)"), rs.getObject(2));
+        assertFalse(rs.next());
+        rs.close();
+        st.close();
+    }
+
+    @Test
     public void test_ST_PointsToLine() throws Exception {
         Statement st = connection.createStatement();
         st.execute("DROP TABLE IF EXISTS input_table;" +


### PR DESCRIPTION
See #41.
### Example usage

``` mysql
SELECT ST_MakePoint(1.4, -3.7);
```

Answer:     `POINT(1.4 -3.7)`

``` mysql
SELECT ST_MakePoint(1.4, -3.7, 6.2);
```

Answer:     `POINT(1.4 -3.7 6.2)`

_Note_: PostGIS has a fourth signature for geometries with measure:

``` mysql
    geometry ST_MakePoint(double precision x, double precision y,
        double precision z, double precision m);
```

But they don't show an example of this. See http://postgis.net/docs/manual-1.4/ST_MakePoint.html
