### PR TITLE
Fix image width

### DIFF
--- a/_includes/css/style.css
+++ b/_includes/css/style.css
@@ -972,4 +972,5 @@ img.displayed {
     display: block;
     margin-left: auto;
     margin-right: auto;
+    max-width:90%;
 }


### PR DESCRIPTION
On mobile phones, images did not display very well because their
dimensions were hard-coded. Now the width is set to be maximum 100% of
the page width. This should fix the problem. @gpetit
