### PR TITLE
Add description metadata when available.

### DIFF
--- a/_includes/top.html
+++ b/_includes/top.html
@@ -2,6 +2,7 @@
 <html lang="en-US">
 <head>
   <meta charset="UTF-8">
+  <meta name="description" content="{{page.description}}" />
   <title>{{ page.title }}</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="alternate" type="application/rss+xml" title="Jekyll • Simple, blog-aware, static sites - Feed" href="/feed.xml" />

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 layout: default
 title: H2GIS &bull; Spatial H2
 overview: true
+description: A spatial extension of the H2 database. Compliant, Solid, Tested.
 ---
 
 <section class="intro">


### PR DESCRIPTION
This should fix the problem we have in Google search results. Currently
we show up as

**H2GIS • Spatial H2**
www.h2gis.org/
wget http://tinyurl.com/h2gis-zip. -O h2gis.zip. ~ $ unzip h2gis.zip. ~
$ cd h2gis-standalone. ~/h2gis-standalone $ ./run.sh. # => Click Connect
in the web interface.

Hopefully after this commit, we will show up as

**H2GIS • Spatial H2**
www.h2gis.org/
A spatial extension of the H2 database. Compliant, Solid, Tested.

Note: Function descriptions from the YAML front-matter should also show
up in search results.
