### PR TITLE
Change return type: Puntal -> Geometry

### DIFF
--- a/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/function/spatial/distance/ST_ClosestCoordinate.java
+++ b/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/function/spatial/distance/ST_ClosestCoordinate.java
@@ -63,7 +63,7 @@ public class ST_ClosestCoordinate extends DeterministicScalarFunction {
      * @return The closest coordinate(s) contained in the given geometry starting from
      *         the given point, using the 2D distance
      */
-    public static Puntal getFurthestCoordinate(Point point, Geometry geom) {
+    public static Geometry getFurthestCoordinate(Point point, Geometry geom) {
         if (point == null || geom == null) {
             return null;
         }

--- a/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/function/spatial/distance/ST_FurthestCoordinate.java
+++ b/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/function/spatial/distance/ST_FurthestCoordinate.java
@@ -63,7 +63,7 @@ public class ST_FurthestCoordinate extends DeterministicScalarFunction {
      * @return The furthest coordinate(s) contained in the given geometry starting from
      *         the given point, using the 2D distance
      */
-    public static Puntal getFurthestCoordinate(Point point, Geometry geom) {
+    public static Geometry getFurthestCoordinate(Point point, Geometry geom) {
         if (point == null || geom == null) {
             return null;
         }


### PR DESCRIPTION
Puntal is a java interface implemented by Point and MultiPoint. Using
this as a return type was a bad idea in H2.
