### PR TITLE
Align tables using dhruvasagar/vim-table-mode

### DIFF
--- a/docs/dev/ST_ClosestPoint.md
+++ b/docs/dev/ST_ClosestPoint.md
@@ -31,9 +31,9 @@ Returns the point of `geomA` closest to `geomB` using 2D distances
 
 ### Examples
 
-| geomA Point | geomB Polygon |
-| ----|---- |
-| POINT(4 8) | LINESTRING(1 2, 3 6, 5 7, 4 1) |
+| geomA Point | geomB Polygon                  |
+|-------------|--------------------------------|
+| POINT(4 8)  | LINESTRING(1 2, 3 6, 5 7, 4 1) |
 
 {% highlight mysql %}
 SELECT  ST_ClosestPoint(geomA, geomB);

--- a/docs/dev/ST_Contains.md
+++ b/docs/dev/ST_Contains.md
@@ -30,44 +30,44 @@ SELECT ST_Contains(geomA, geomB) FROM input_table;
 -- Answer:    True
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) | POLYGON ((2 2, 7 2, 7 5, 2 5, 2 2)) |
 
 <img class="displayed" src="../ST_Contains_1.png"/>
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) | POLYGON ((1 2, 6 2, 6 5, 1 5, 1 2)) |
 
 <img class="displayed" src="../ST_Contains_4.png"/>
 
-| geomA POLYGON | geomB LINESTRING |
-| ----|---- |
+| geomA POLYGON                       | geomB LINESTRING      |
+|-------------------------------------|-----------------------|
 | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) | LINESTRING (2 6, 6 2) |
 
 <img class="displayed" src="../ST_Contains_2.png"/>
 
-| geomA POLYGON | geomB LINESTRING |
-| ----|---- |
+| geomA POLYGON                       | geomB LINESTRING           |
+|-------------------------------------|----------------------------|
 | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) | LINESTRING (1 2, 1 6, 5 2) |
 
 <img class="displayed" src="../ST_Contains_5.png"/>
 
-| geomA POLYGON | geomB POINT |
-| ----|---- |
+| geomA POLYGON                       | geomB POINT |
+|-------------------------------------|-------------|
 | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) | POINT (4 4) |
 
 <img class="displayed" src="../ST_Contains_3.png"/>
 
-| geomA LINESTRING | geomB LINESTRING |
-| ----|---- |
+| geomA LINESTRING           | geomB LINESTRING      |
+|----------------------------|-----------------------|
 | LINESTRING (2 1, 5 3, 2 6) | LINESTRING (3 5, 5 3) |
 
 <img class="displayed" src="../ST_Contains_10.png"/>
 
-| geomA LINESTRING | geomB POINT |
-| ----|---- |
+| geomA LINESTRING           | geomB POINT |
+|----------------------------|-------------|
 | LINESTRING (2 1, 5 3, 2 6) | POINT (4 4) |
 
 <img class="displayed" src="../ST_Contains_11.png"/>
@@ -79,32 +79,32 @@ SELECT ST_Contains(geomA, geomB) FROM input_table;
 -- Answer:    False
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) | POLYGON ((0 2, 5 2, 5 5, 0 5, 0 2)) |
 
 <img class="displayed" src="../ST_Contains_7.png"/>
 
-| geomA POLYGON | geomB LINESTRING |
-| ----|---- |
+| geomA POLYGON                       | geomB LINESTRING      |
+|-------------------------------------|-----------------------|
 | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) | LINESTRING (2 6, 0 8) |
 
 <img class="displayed" src="../ST_Contains_8.png"/>
 
-| geomA POLYGON | geomB LINESTRING |
-| ----|---- |
+| geomA POLYGON                       | geomB LINESTRING      |
+|-------------------------------------|-----------------------|
 | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) | LINESTRING (1 2, 1 6) |
 
 <img class="displayed" src="../ST_Contains_12.png"/>
 
-| geomA POLYGON | geomB POINT |
-| ----|---- |
+| geomA POLYGON                       | geomB POINT |
+|-------------------------------------|-------------|
 | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) | POINT (8 4) |
 
 <img class="displayed" src="../ST_Contains_6.png"/>
 
-| geomA POLYGON | geomB POINT |
-| ----|---- |
+| geomA POLYGON                       | geomB POINT |
+|-------------------------------------|-------------|
 | POLYGON ((1 1, 7 1, 7 7, 1 7, 1 1)) | POINT (8 4) |
 
 <img class="displayed" src="../ST_Contains_9.png"/>

--- a/docs/dev/ST_Covers.md
+++ b/docs/dev/ST_Covers.md
@@ -20,8 +20,8 @@ Returns true if no point in `geomB` is outside `geomA`.
 
 ### Examples
 
-| smallc POLYGON | bigc POLYGON |
-| ----|---- |
+| smallc POLYGON                     | bigc POLYGON                         |
+|------------------------------------|--------------------------------------|
 | POLYGON((1 1, 5 1, 5 4, 1 4, 1 1)) | POLYGON((0 0, 10 0, 10 5, 0 5, 0 0)) |
 
 <img class="displayed" src="../ST_Covers.png"/>

--- a/docs/dev/ST_Crosses.md
+++ b/docs/dev/ST_Crosses.md
@@ -39,44 +39,44 @@ SELECT ST_Crosses(geomA, geomB) FROM input_table;
 -- Answer:    True
 {% endhighlight %}
 
-| geomA MULTIPOINT | geomB LINESTRING |
-| ----|---- |
+| geomA MULTIPOINT                 | geomB LINESTRING           |
+|----------------------------------|----------------------------|
 | MULTIPOINT ((1 3), (4 1), (4 3)) | LINESTRING (1 1, 5 2, 2 5) |
 
 <img class="displayed" src="../ST_Crosses_1.png"/>
 
-| geomA MULTIPOINT | geomB POLYGON |
-| ----|---- |
+| geomA MULTIPOINT                 | geomB POLYGON                       |
+|----------------------------------|-------------------------------------|
 | MULTIPOINT ((1 3), (4 1), (4 3)) | POLYGON ((2 2, 5 2, 5 5, 2 5, 2 2)) |
 
 <img class="displayed" src="../ST_Crosses_2.png"/>
 
-| geomA LINESTRING | geomB LINESTRING |
-| ----|---- |
+| geomA LINESTRING      | geomB LINESTRING           |
+|-----------------------|----------------------------|
 | LINESTRING (1 3, 5 3) | LINESTRING (1 1, 5 2, 2 5) |
 
 <img class="displayed" src="../ST_Crosses_3.png"/>
 
-| geomA LINESTRING | geomB POLYGON |
-| ----|---- |
+| geomA LINESTRING      | geomB POLYGON                       |
+|-----------------------|-------------------------------------|
 | LINESTRING (1 3, 5 3) | POLYGON ((2 2, 5 2, 5 5, 2 5, 2 2)) |
 
 <img class="displayed" src="../ST_Crosses_4.png"/>
 
-| geomA POLYGON | geomB LINESTRING |
-| ----|---- |
+| geomA POLYGON                       | geomB LINESTRING      |
+|-------------------------------------|-----------------------|
 | POLYGON ((1 1, 4 1, 4 4, 1 4, 1 1)) | LINESTRING (1 5, 5 1) |
 
 <img class="displayed" src="../ST_Crosses_5.png"/>
 
-| geomA POLYGON | geomB MULTIPOINT |
-| ----|---- |
+| geomA POLYGON                       | geomB MULTIPOINT                 |
+|-------------------------------------|----------------------------------|
 | POLYGON ((1 1, 4 1, 4 4, 1 4, 1 1)) | MULTIPOINT ((2 3), (4 5), (5 1)) |
 
 <img class="displayed" src="../ST_Crosses_6.png"/>
 
-| geomA LINESTRING | geomB MULTIPOINT |
-| ----|---- |
+| geomA LINESTRING           | geomB MULTIPOINT                 |
+|----------------------------|----------------------------------|
 | LINESTRING (2 1, 1 3, 3 4) | MULTIPOINT ((1 3), (4 1), (4 3)) |
 
 <img class="displayed" src="../ST_Crosses_7.png"/>
@@ -88,14 +88,14 @@ SELECT ST_Crosses(geomA, geomB) FROM input_table;
 -- Answer:    False
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 4, 1 4, 1 1)) | POLYGON ((2 2, 5 2, 5 5, 2 5, 2 2)) |
 
 <img class="displayed" src="../ST_Crosses_9.png"/>
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON              | geomB POLYGON         |
+|----------------------------|-----------------------|
 | LINESTRING (1 1, 5 2, 2 5) | LINESTRING (3 4, 5 2) |
 
 <img class="displayed" src="../ST_Crosses_8.png"/>

--- a/docs/dev/ST_DWithin.md
+++ b/docs/dev/ST_DWithin.md
@@ -21,8 +21,8 @@ Returns true if `geomA` is within `distance` of `geomB`.
 ### Examples
 
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                        | geomB POLYGON                           |
+|--------------------------------------|-----------------------------------------|
 | POLYGON((0 0, 10 0, 10 5, 0 5, 0 0)) | POLYGON((12 0, 14 0, 14 6, 12 6, 12 0)) |
 
 <img class="displayed" src="../ST_DWithin.png"/>

--- a/docs/dev/ST_Difference.md
+++ b/docs/dev/ST_Difference.md
@@ -22,8 +22,8 @@ Computes the difference between `geomA` and `geomB`.
 
 ### Examples
 
-| geomA Polygon | geomB Polygon |
-| ----|---- |
+| geomA Polygon                      | geomB Polygon                      |
+|------------------------------------|------------------------------------|
 | POLYGON((1 1, 7 1, 7 6, 1 6, 1 1)) | POLYGON((3 2, 8 2, 8 8, 3 8, 3 2)) |
 
 {% highlight mysql %}

--- a/docs/dev/ST_Disjoint.md
+++ b/docs/dev/ST_Disjoint.md
@@ -32,20 +32,20 @@ SELECT ST_Disjoint(geomA, geomB) FROM input_table;
 -- Answer:    True
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | POLYGON ((6 3, 7 3, 7 6, 6 6, 6 3)) |
 
 <img class="displayed" src="../ST_Disjoint_1.png"/>
 
-| geomA LINESTRING | geomB LINESTRING |
-| ----|---- |
+| geomA LINESTRING           | geomB LINESTRING      |
+|----------------------------|-----------------------|
 | LINESTRING (2 1, 5 3, 2 6) | LINESTRING (6 2, 6 6) |
 
 <img class="displayed" src="../ST_Disjoint_2.png"/>
 
-| geomA LINESTRING | geomB POINT |
-| ----|---- |
+| geomA LINESTRING           | geomB POINT |
+|----------------------------|-------------|
 | LINESTRING (2 1, 5 3, 2 6) | POINT (4 5) |
 
 <img class="displayed" src="../ST_Disjoint_3.png"/>
@@ -57,14 +57,14 @@ SELECT ST_Disjoint(geomA, geomB) FROM input_table;
 -- Answer:    False
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | POLYGON ((3 2, 6 2, 6 6, 3 6, 3 2)) |
 
 <img class="displayed" src="../ST_Disjoint_4.png"/>
 
-| geomA POLYGON | geomB MULTIPOLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB MULTIPOLYGON                                                      |
+|-------------------------------------|-------------------------------------------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | MULTIPOLYGON (((4 2, 7 2, 7 6, 4 6, 4 2)), ((0 6, 1 6, 1 7, 0 7, 0 6))) |
 
 <img class="displayed" src="../ST_Disjoint_5.png"/>

--- a/docs/dev/ST_Envelope.md
+++ b/docs/dev/ST_Envelope.md
@@ -23,11 +23,11 @@ Returns the envelope of `geom` as a Geometry, optionally setting its SRID to
 `srid`. The default SRID is the same as that of `geom`.
 <!-- If `geom` is empty, returns an empty `POINT`. -->
 
-| Input type | Return type |
-|------------|-------------|
-| A `POINT` | `POINT` |
-| A line parallel to an axis | A two-vertex `LINESTRING` |
-| Otherwise | A `POLYGON` whose vertices are `(minx miny, maxx miny, maxx maxy, minx maxy, minx miny)` |
+| Input type                 | Return type                                                                              |
+|----------------------------|------------------------------------------------------------------------------------------|
+| A `POINT`                  | `POINT`                                                                                  |
+| A line parallel to an axis | A two-vertex `LINESTRING`                                                                |
+| Otherwise                  | A `POLYGON` whose vertices are `(minx miny, maxx miny, maxx maxy, minx maxy, minx miny)` |
 
 {% include sfs-1-2-1.html %}
 <!-- Is this function also SQL-MM? -->

--- a/docs/dev/ST_Equals.md
+++ b/docs/dev/ST_Equals.md
@@ -33,20 +33,20 @@ SELECT ST_Equals(geomA, geomB) FROM input_table;
 -- Answer:    True
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 4, 1 4, 1 1)) | POLYGON ((1 1, 4 1, 4 4, 1 4, 1 1)) |
 
 <img class="displayed" src="../ST_Equals_1.png"/>
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 4, 1 4, 1 1)) | POLYGON ((4 4, 4 1, 1 1, 1 4, 4 4)) |
 
 <img class="displayed" src="../ST_Equals_2.png"/>
 
-| geomA LINESTRING | geomB LINESTRING |
-| ----|---- |
+| geomA LINESTRING      | geomB LINESTRING           |
+|-----------------------|----------------------------|
 | LINESTRING (1 1, 4 4) | LINESTRING (1 1, 3 3, 4 4) |
 
 <img class="displayed" src="../ST_Equals_3.png"/>

--- a/docs/dev/ST_Graph.md
+++ b/docs/dev/ST_Graph.md
@@ -25,11 +25,11 @@ Produces two tables (nodes and edges) from the geometries contained in column
 `columnName` of table `inputTable`. If no column is specified, then the first
 Geometry column is used. Returns `true` if the operation is successful.
 
-| Variable | Default value |
-| - | - |
-| `columnName` | The first geometry column found |
-| `tolerance` | `0.0` |
-| `orientBySlope` | `false` |
+| Variable        | Default value                   |
+|-----------------|---------------------------------|
+| `columnName`    | The first geometry column found |
+| `tolerance`     | `0.0`                           |
+| `orientBySlope` | `false`                         |
 
 <div class="note warning">
   <h5>The column must only contain <code>LINESTRING</code>s or

--- a/docs/dev/ST_Intersection.md
+++ b/docs/dev/ST_Intersection.md
@@ -24,8 +24,8 @@ Computes the intersection between `geomA` and `geomB`.
 
 ### Examples
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 7 1, 7 6, 1 6, 1 1)) | POLYGON ((3 2, 8 2, 8 8, 3 8, 3 2)) |
 
 {% highlight mysql %}
@@ -35,8 +35,8 @@ SELECT ST_Intersection(geomA, geomB) FROM input_table;
 
 <img class="displayed" src="../ST_Intersection_1.png"/>
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 6, 1 6, 1 1)) | POLYGON ((4 2, 8 2, 8 8, 4 8, 4 2)) |
 
 {% highlight mysql %}
@@ -46,8 +46,8 @@ SELECT ST_Intersection(geomA, geomB) FROM input_table;
 
 <img class="displayed" src="../ST_Intersection_2.png"/>
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 6, 1 6, 1 1)) | POLYGON ((4 6, 8 6, 8 8, 4 8, 4 6)) |
 
 {% highlight mysql %}
@@ -57,8 +57,8 @@ SELECT ST_Intersection(geomA, geomB) FROM input_table;
 
 <img class="displayed" src="../ST_Intersection_6.png"/>
 
-| geomA POLYGON | geomB LINESTRING |
-| ----|---- |
+| geomA POLYGON                       | geomB LINESTRING      |
+|-------------------------------------|-----------------------|
 | POLYGON ((1 1, 7 1, 7 6, 1 6, 1 1)) | LINESTRING (2 8, 8 2) |
 
 {% highlight mysql %}
@@ -68,8 +68,8 @@ SELECT ST_Intersection(geomA, geomB) FROM input_table;
 
 <img class="displayed" src="../ST_Intersection_3.png"/>
 
-| geomA LINESTRING | geomB LINESTRING |
-| ----|---- |
+| geomA LINESTRING      | geomB LINESTRING      |
+|-----------------------|-----------------------|
 | LINESTRING (2 2, 6 6) | LINESTRING (2 8, 8 2) |
 
 {% highlight mysql %}
@@ -79,8 +79,8 @@ SELECT ST_Intersection(geomA, geomB) FROM input_table;
 
 <img class="displayed" src="../ST_Intersection_4.png"/>
 
-| geomA POLYGON | geomB POINT |
-| ----|---- |
+| geomA POLYGON                       | geomB POINT |
+|-------------------------------------|-------------|
 | POLYGON ((1 1, 7 1, 7 6, 1 6, 1 1)) | POINT (3 5) |
 
 {% highlight mysql %}

--- a/docs/dev/ST_Intersects.md
+++ b/docs/dev/ST_Intersects.md
@@ -32,50 +32,50 @@ SELECT ST_Intersects(geomA, geomB) FROM input_table;
 -- Answer:    True
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | POLYGON ((3 2, 6 2, 6 6, 3 6, 3 2)) |
 
 <img class="displayed" src="../ST_Intersects_1.png"/>
 
-| geomA POLYGON | geomB LINESTRING |
-| ----|---- |
+| geomA POLYGON                       | geomB LINESTRING      |
+|-------------------------------------|-----------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | LINESTRING (2 4, 7 4) |
 
 <img class="displayed" src="../ST_Intersects_2.png"/>
 
-| geomA POLYGON | geomB POINT |
-| ----|---- |
+| geomA POLYGON                       | geomB POINT |
+|-------------------------------------|-------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | POINT (3 3) |
 
 <img class="displayed" src="../ST_Intersects_3.png"/>
 
-| geomA LINESTRING | geomB LINESTRING |
-| ----|---- |
+| geomA LINESTRING           | geomB LINESTRING      |
+|----------------------------|-----------------------|
 | LINESTRING (2 1, 5 3, 2 6) | LINESTRING (1 3, 4 6) |
 
 <img class="displayed" src="../ST_Intersects_4.png"/>
 
-| geomA LINESTRING | geomB POINT |
-| ----|---- |
+| geomA LINESTRING           | geomB POINT |
+|----------------------------|-------------|
 | LINESTRING (2 1, 5 3, 2 6) | POINT (2 6) |
 
 <img class="displayed" src="../ST_Intersects_5.png"/>
 
-| geomA POLYGON | geomB MULTIPOLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB MULTIPOLYGON                                                      |
+|-------------------------------------|-------------------------------------------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | MULTIPOLYGON (((4 2, 7 2, 7 6, 4 6, 4 2)), ((0 6, 1 6, 1 7, 0 7, 0 6))) |
 
 <img class="displayed" src="../ST_Intersects_6.png"/>
 
-| geomA POLYGON | geomB MULTILINESTRING |
-| ----|---- |
+| geomA POLYGON                       | geomB MULTILINESTRING                    |
+|-------------------------------------|------------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | MULTILINESTRING ((2 5, 7 5), (6 1, 6 4)) |
 
 <img class="displayed" src="../ST_Intersects_7.png"/>
 
-| geomA POLYGON | geomB MULTIPOINT |
-| ----|---- |
+| geomA POLYGON                       | geomB MULTIPOINT          |
+|-------------------------------------|---------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | MULTIPOINT ((4 3), (6 2)) |
 
 <img class="displayed" src="../ST_Intersects_8.png"/>
@@ -87,8 +87,8 @@ SELECT ST_Intersects(geomA, geomB) FROM input_table;
 -- Answer:    False
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | POLYGON ((6 3, 7 3, 7 6, 6 6, 6 3)) |
 
 <img class="displayed" src="../ST_Intersects_9.png"/>

--- a/docs/dev/ST_Overlaps.md
+++ b/docs/dev/ST_Overlaps.md
@@ -36,26 +36,26 @@ SELECT ST_Overlaps(geomA, geomB) FROM input_table;
 -- Answer:    True
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | POLYGON ((3 2, 6 2, 6 6, 3 6, 3 2)) |
 
 <img class="displayed" src="../ST_Overlaps_1.png"/>
 
-| geomA LINESTRING | geomB LINESTRING |
-| ----|---- |
+| geomA LINESTRING           | geomB LINESTRING           |
+|----------------------------|----------------------------|
 | LINESTRING (2 1, 5 3, 2 6) | LINESTRING (3 5, 4 4, 6 7) |
 
 <img class="displayed" src="../ST_Overlaps_2.png"/>
 
-| geomA MULTIPOINT | geomB MULTIPOINT |
-| ----|---- |
+| geomA MULTIPOINT                        | geomB MULTIPOINT                 |
+|-----------------------------------------|----------------------------------|
 | MULTIPOINT ((5 1), (3 3), (2 5), (4 5)) | MULTIPOINT ((3 3), (5 4), (2 6)) |
 
 <img class="displayed" src="../ST_Overlaps_3.png"/>
 
-| geomA POLYGON | geomB MULTIPOLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB MULTIPOLYGON                                                      |
+|-------------------------------------|-------------------------------------------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | MULTIPOLYGON (((3 2, 6 2, 6 6, 3 6, 3 2)), ((0 6, 1 6, 1 7, 0 7, 0 6))) |
 
 <img class="displayed" src="../ST_Overlaps_4.png"/>
@@ -67,14 +67,14 @@ SELECT ST_Overlaps(geomA, geomB) FROM input_table;
 -- Answer:    False
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | POLYGON ((4 5, 7 5, 7 6, 4 6, 4 5)) |
 
 <img class="displayed" src="../ST_Overlaps_5.png"/>
 
-| geomA LINESTRING | geomB LINESTRING |
-| ----|---- |
+| geomA LINESTRING           | geomB LINESTRING      |
+|----------------------------|-----------------------|
 | LINESTRING (2 1, 5 3, 2 6) | LINESTRING (1 3, 4 6) |
 
 <img class="displayed" src="../ST_Overlaps_6.png"/>

--- a/docs/dev/ST_SymDifference.md
+++ b/docs/dev/ST_SymDifference.md
@@ -22,8 +22,8 @@ Computes the symmetric difference between `geomA` and `geomB`.
 
 ### Example
 
-| geomA Polygon | geomB Polygon |
-| ----|---- |
+| geomA Polygon                      | geomB Polygon                      |
+|------------------------------------|------------------------------------|
 | POLYGON((1 1, 7 1, 7 6, 1 6, 1 1)) | POLYGON((3 2, 8 2, 8 8, 3 8, 3 2)) |
 
 {% highlight mysql %}

--- a/docs/dev/ST_Touches.md
+++ b/docs/dev/ST_Touches.md
@@ -37,56 +37,56 @@ SELECT ST_Touches(geomA, geomB) FROM input_table;
 -- Answer:    True
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | POLYGON ((4 2, 7 2, 7 6, 4 6, 4 2)) |
 
 <img class="displayed" src="../ST_Touches_1.png"/>
 
-| geomA POLYGON | geomB LINESTRING |
-| ----|---- |
+| geomA POLYGON                       | geomB LINESTRING      |
+|-------------------------------------|-----------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | LINESTRING (2 5, 7 5) |
 
 <img class="displayed" src="../ST_Touches_2.png"/>
 
-| geomA POLYGON | geomB POINT |
-| ----|---- |
+| geomA POLYGON                       | geomB POINT |
+|-------------------------------------|-------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | POINT (4 3) |
 
 <img class="displayed" src="../ST_Touches_3.png"/>
 
-| geomA LINESTRING | geomB LINESTRING |
-| ----|---- |
+| geomA LINESTRING           | geomB LINESTRING      |
+|----------------------------|-----------------------|
 | LINESTRING (2 1, 5 3, 2 6) | LINESTRING (1 3, 3 5) |
 
 <img class="displayed" src="../ST_Touches_4.png"/>
 
-| geomA LINESTRING | geomB POINT |
-| ----|---- |
+| geomA LINESTRING           | geomB POINT |
+|----------------------------|-------------|
 | LINESTRING (2 1, 5 3, 2 6) | POINT (2 6) |
 
 <img class="displayed" src="../ST_Touches_5.png"/>
 
-| geomA POLYGON | geomB MULTIPOLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB MULTIPOLYGON                                                      |
+|-------------------------------------|-------------------------------------------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | MULTIPOLYGON (((4 2, 7 2, 7 6, 4 6, 4 2)), ((0 6, 1 6, 1 7, 0 7, 0 6))) |
 
 <img class="displayed" src="../ST_Touches_6.png"/>
 
-| geomA POLYGON | geomB MULTILINESTRING |
-| ----|---- |
+| geomA POLYGON                       | geomB MULTILINESTRING                    |
+|-------------------------------------|------------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | MULTILINESTRING ((2 5, 7 5), (6 1, 6 4)) |
 
 <img class="displayed" src="../ST_Touches_7.png"/>
 
-| geomA POLYGON | geomB MULTIPOINT |
-| ----|---- |
+| geomA POLYGON                       | geomB MULTIPOINT          |
+|-------------------------------------|---------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | MULTIPOINT ((4 3), (6 2)) |
 
 <img class="displayed" src="../ST_Touches_8.png"/>
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | POLYGON ((4 5, 7 5, 7 6, 4 6, 4 5)) |
 
 <img class="displayed" src="../ST_Touches_9.png"/>
@@ -98,8 +98,8 @@ SELECT ST_Touches(geomA, geomB) FROM input_table;
 -- Answer:    False
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 1, 4 1, 4 5, 1 5, 1 1)) | POLYGON ((3 4, 7 4, 7 6, 3 6, 3 4)) |
 
 <img class="displayed" src="../ST_Touches_10.png"/>

--- a/docs/dev/ST_Union.md
+++ b/docs/dev/ST_Union.md
@@ -40,8 +40,8 @@ Computes the union of a set of Geometries.
 
 ##### Scalar function
 
-| geomA Polygon | geomB Polygon |
-| ----|---- |
+| geomA Polygon                      | geomB Polygon                      |
+|------------------------------------|------------------------------------|
 | POLYGON((1 1, 7 1, 7 6, 1 6, 1 1)) | POLYGON((3 2, 8 2, 8 8, 3 8, 3 2)) |
 
 {% highlight mysql %}

--- a/docs/dev/ST_Within.md
+++ b/docs/dev/ST_Within.md
@@ -37,44 +37,44 @@ SELECT ST_Within(geomA, geomB) FROM input_table;
 -- Answer:    True
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((2 2, 7 2, 7 5, 2 5, 2 2)) | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) |
 
 <img class="displayed" src="../ST_Within_1.png"/>
 
-| geomA LINESTRING | geomB POLYGON |
-| ----|---- |
+| geomA LINESTRING      | geomB POLYGON                       |
+|-----------------------|-------------------------------------|
 | LINESTRING (2 6, 6 2) | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) |
 
 <img class="displayed" src="../ST_Within_2.png"/>
 
-| geomA POINT | geomB POLYGON |
-| ----|---- |
+| geomA POINT | geomB POLYGON                       |
+|-------------|-------------------------------------|
 | POINT (4 4) | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) |
 
 <img class="displayed" src="../ST_Within_3.png"/>
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((1 2, 6 2, 6 5, 1 5, 1 2)) | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) |
 
 <img class="displayed" src="../ST_Within_4.png"/>
 
-| geomA LINESTRING | geomB POLYGON |
-| ----|---- |
+| geomA LINESTRING           | geomB POLYGON                       |
+|----------------------------|-------------------------------------|
 | LINESTRING (1 2, 1 6, 5 2) | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) |
 
 <img class="displayed" src="../ST_Within_5.png"/>
 
-| geomA LINESTRING | geomB LINESTRING |
-| ----|---- |
+| geomA LINESTRING      | geomB LINESTRING           |
+|-----------------------|----------------------------|
 | LINESTRING (3 5, 5 3) | LINESTRING (2 1, 5 3, 2 6) |
 
 <img class="displayed" src="../ST_Within_6.png"/>
 
-| geomA POINT | geomB LINESTRING |
-| ----|---- |
+| geomA POINT | geomB LINESTRING           |
+|-------------|----------------------------|
 | POINT (4 4) | LINESTRING (2 1, 5 3, 2 6) |
 
 <img class="displayed" src="../ST_Within_7.png"/>
@@ -86,26 +86,26 @@ SELECT ST_Within(geomA, geomB) FROM input_table;
 -- Answer:    False
 {% endhighlight %}
 
-| geomA POLYGON | geomB POLYGON |
-| ----|---- |
+| geomA POLYGON                       | geomB POLYGON                       |
+|-------------------------------------|-------------------------------------|
 | POLYGON ((0 2, 5 2, 5 5, 0 5, 0 2)) | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) |
 
 <img class="displayed" src="../ST_Within_8.png"/>
 
-| geomA LINESTRING | geomB POLYGON |
-| ----|---- |
+| geomA LINESTRING      | geomB POLYGON                       |
+|-----------------------|-------------------------------------|
 | LINESTRING (2 6, 0 8) | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) |
 
 <img class="displayed" src="../ST_Within_9.png"/>
 
-| geomA POINT | geomB POLYGON |
-| ----|---- |
+| geomA POINT | geomB POLYGON                       |
+|-------------|-------------------------------------|
 | POINT (8 4) | POLYGON ((1 1, 8 1, 8 7, 1 7, 1 1)) |
 
 <img class="displayed" src="../ST_Within_10.png"/>
 
-| geomA POINT | geomB POLYGON |
-| ----|---- |
+| geomA POINT | geomB POLYGON                       |
+|-------------|-------------------------------------|
 | POINT (8 4) | POLYGON ((1 1, 7 1, 7 7, 1 7, 1 1)) |
 
 <img class="displayed" src="../ST_Within_11.png"/>

--- a/docs/dev/getting-started/spatial-indices.md
+++ b/docs/dev/getting-started/spatial-indices.md
@@ -52,9 +52,9 @@ SELECT idarea, COUNT(idroad) roadscount
 Result:
 
 | IDAREA | ROADSCOUNT |
-| - | - |
-| 1 | 2 |
-| 2 | 1 |
+|--------|------------|
+|      1 |          2 |
+|      2 |          1 |
 
 Note that [`ST_Intersects`](../ST_Intersects) does not yet support spatial
 indices, but it will in a future release.


### PR DESCRIPTION
This little PR just makes Markdown tables look nice. Doesn't change anything in the HTML output. I used [vim-table-mode](https://github.com/dhruvasagar/vim-table-mode) to automate the process.

Sublime Text 2 users should see [SublimeTableEditor](https://github.com/vkocubinsky/SublimeTableEditor).
