### PR TITLE
Fix escape field name and table name

### DIFF
--- a/h2drivers/src/main/java/org/h2gis/drivers/dbf/DBFDriverFunction.java
+++ b/h2drivers/src/main/java/org/h2gis/drivers/dbf/DBFDriverFunction.java
@@ -189,7 +189,7 @@ public class DBFDriverFunction implements DriverFunction {
             if(idColumn > 0) {
                 stringBuilder.append(", ");
             }
-            stringBuilder.append(header.getFieldName(idColumn));
+            stringBuilder.append(TableLocation.escapeIdentifier(header.getFieldName(idColumn)));
             stringBuilder.append(" ");
             switch (header.getFieldType(idColumn)) {
                 // (L)logical (T,t,F,f,Y,y,N,n)

--- a/h2drivers/src/test/java/org/h2gis/drivers/gpx/GPXImportTest.java
+++ b/h2drivers/src/test/java/org/h2gis/drivers/gpx/GPXImportTest.java
@@ -61,7 +61,7 @@ public class GPXImportTest {
     @Test
     public void importGPXWaypoints() throws SQLException {
         Statement st = connection.createStatement();
-        st.execute("DROP TABLE IF EXISTS GPXDATA_WAYPOINT");
+        st.execute("DROP TABLE IF EXISTS GPXDATA_WAYPOINT,gpxdata_waypoint");
         st.execute("CALL GPXRead(" + StringUtils.quoteStringSQL(GPXImportTest.class.getResource("waypoint.gpx").getPath()) + ", 'gpxdata');");
         ResultSet rs = st.executeQuery("SELECT * FROM INFORMATION_SCHEMA.COLUMNS where TABLE_NAME = 'GPXDATA_WAYPOINT'");
         assertTrue(rs.next());
@@ -110,7 +110,7 @@ public class GPXImportTest {
     @Test
     public void importGPXTrack() throws SQLException {
         Statement st = connection.createStatement();
-        st.execute("DROP TABLE IF EXISTS GPXDATA_TRACK, GPXDATA_TRACKSEGMENT,GPXDATA_TRACKPOINT;");
+        st.execute("DROP TABLE IF EXISTS GPXDATA_TRACK, GPXDATA_TRACKSEGMENT,GPXDATA_TRACKPOINT,gpxdata_route;");
         st.execute("CALL GPXRead(" + StringUtils.quoteStringSQL(GPXImportTest.class.getResource("track.gpx").getPath()) + ", 'gpxdata');");
         ResultSet rs = st.executeQuery("SELECT * FROM INFORMATION_SCHEMA.COLUMNS where TABLE_NAME = 'GPXDATA_TRACK'");
         assertTrue(rs.next());

--- a/spatial-utilities/src/test/java/org/h2gis/utilities/SFSUtilitiesTest.java
+++ b/spatial-utilities/src/test/java/org/h2gis/utilities/SFSUtilitiesTest.java
@@ -67,7 +67,7 @@ public class SFSUtilitiesTest {
         assertEquals("mydb",location.getCatalog());
         assertEquals("myschema",location.getSchema());
         assertEquals("mytable.hello",location.getTable());
-        assertEquals("mydb.myschema.mytable.hello", location.toString());
+        assertEquals("mydb.myschema.\"mytable.hello\"", location.toString());
         location = TableLocation.parse("`mydb`.`my schema`.`my table`");
         assertEquals("mydb",location.getCatalog());
         assertEquals("my schema",location.getSchema());


### PR DESCRIPTION
TableLocation.escapeIdentifier() will make it easier to deal with table and field names with the H2 and PostGre databases.
