### PR TITLE
Remove the extra call to ST_Graph (#240)

### DIFF
--- a/h2network/src/test/java/org/h2gis/network/SpatialFunctionTest.java
+++ b/h2network/src/test/java/org/h2gis/network/SpatialFunctionTest.java
@@ -27,7 +27,6 @@ package org.h2gis.network;
 import org.h2.value.ValueGeometry;
 import org.h2gis.h2spatial.CreateSpatialExtension;
 import org.h2gis.h2spatial.ut.SpatialH2UT;
-import org.h2gis.network.graph_creator.GraphCreatorTest;
 import org.h2gis.network.graph_creator.ST_Graph;
 import org.h2gis.network.graph_creator.ST_ShortestPathLength;
 import org.junit.*;
@@ -54,7 +53,6 @@ public class SpatialFunctionTest {
         connection = SpatialH2UT.createSpatialDataBase(DB_NAME, true);
         CreateSpatialExtension.registerFunction(connection.createStatement(), new ST_Graph(), "");
         CreateSpatialExtension.registerFunction(connection.createStatement(), new ST_ShortestPathLength(), "");
-        GraphCreatorTest.registerCormenGraph(connection);
     }
 
     @Before


### PR DESCRIPTION
This explains the extra call to `ST_Graph` in #240 ... it's my stupid mistake.

I was calling it an extra time when I created the cormen graph, but I
don't need the cormen graph for the `ST_Graph` tests!
