### PR TITLE
Fix URIUtility.relativize with space in path

### DIFF
--- a/spatial-utilities/src/main/java/org/h2gis/utilities/URIUtility.java
+++ b/spatial-utilities/src/main/java/org/h2gis/utilities/URIUtility.java
@@ -26,6 +26,7 @@ package org.h2gis.utilities;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
@@ -149,6 +150,10 @@ public class URIUtility {
             rel.append(separator);
             rel.append(targetPart);
         }
-        return URI.create(rel.toString());
+        try {
+            return new URI(null, null, rel.toString(), null, null);
+        } catch (URISyntaxException ex) {
+            throw new IllegalArgumentException("Illegal URI provided:\n"+base.toString()+"\n"+target.toString());
+        }
     }
 }

--- a/spatial-utilities/src/test/java/org/h2gis/utilities/URIUtilityTest.java
+++ b/spatial-utilities/src/test/java/org/h2gis/utilities/URIUtilityTest.java
@@ -26,6 +26,7 @@ package org.h2gis.utilities;
 
 import org.junit.Test;
 
+import java.io.File;
 import java.net.URI;
 import java.util.Map;
 import static org.junit.Assert.assertEquals;
@@ -87,5 +88,12 @@ public class URIUtilityTest {
         folder = new URI("file:///home/user/OrbisGIS/maps/landcover/folder/bla.ows");
         rel = new URI("file:///home/user/OrbisGIS/maps/landcover/data/data.shp");
         assertEquals("../data/data.shp", URIUtility.relativize(folder, rel).toString());
+    }
+
+    @Test
+    public void testRelativizeSpace() throws Exception {
+        URI rel = new URI("file:///home/user/OrbisGIS/maps/landcover/bla%20bla/text.txt");
+        URI folder = new URI("file:///home/user/OrbisGIS/maps/landcover/folder/");
+        assertEquals("../bla%20bla/text.txt", URIUtility.relativize(folder, rel).toString());
     }
 }


### PR DESCRIPTION
Handle special characters in path like spaces. This error led to an exception on MapContext save in OrbisGIS.
