### PR TITLE
Add unit test for edges with infinite weights

### DIFF
--- a/h2network/src/test/java/org/h2gis/network/graph_creator/GraphCreatorTest.java
+++ b/h2network/src/test/java/org/h2gis/network/graph_creator/GraphCreatorTest.java
@@ -153,6 +153,27 @@ public class GraphCreatorTest {
                 "('LINESTRING (4 2, 5 2)', 12, 2.0, 1, 12, 7, 8)");
         st.execute("ALTER TABLE copy_edges_all ALTER COLUMN ID SET NOT NULL");
         st.execute("CREATE PRIMARY KEY ON copy_edges_all(ID)");
+        // Here we create a copy with edges 3, 4, 6, 8, 10 having a weight of
+        // Infinity. Setting an edge's weight to Infinity is equivalent to
+        // deleting the edge from the graph.
+//                 2:1
+//           >2 <----------- 4
+//          /                 ^
+//     1:10/                  |
+//        /                   |
+//       /                    |9:6
+//      1                     |
+//       \                    |
+//     5:5\                   /
+//         \       7:2       |
+//          > 3 -----------> 5
+//             INF_EDGES_ALL
+        st.execute("DROP TABLE IF EXISTS inf_edges_all");
+        st.execute("CREATE TABLE inf_edges_all AS SELECT * FROM cormen_edges_all");
+        st.execute("UPDATE inf_edges_all SET WEIGHT=POWER(0, -1) WHERE " +
+                "EDGE_ID=3 OR EDGE_ID=4 OR EDGE_ID=6 OR EDGE_ID=8 OR EDGE_ID=10;");
+        st.execute("ALTER TABLE inf_edges_all ALTER COLUMN ID SET NOT NULL");
+        st.execute("CREATE PRIMARY KEY ON inf_edges_all(ID)");
     }
 
     @Test

--- a/h2network/src/test/java/org/h2gis/network/graph_creator/ST_ShortestPathLengthTest.java
+++ b/h2network/src/test/java/org/h2gis/network/graph_creator/ST_ShortestPathLengthTest.java
@@ -39,7 +39,7 @@ import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Created by adam on 3/6/14.
+ * @author Adam Gouge
  */
 public class ST_ShortestPathLengthTest {
 
@@ -583,6 +583,10 @@ public class ST_ShortestPathLengthTest {
                 "SELECT * FROM ST_ShortestPathLength('cormen_edges_all', "
                         + orientation + ((weight != null) ? ", " + weight : "")
                         + ", " + sourceDestinationTable + ")");
+        checkManyToMany(rs, distances);
+    }
+
+    private void checkManyToMany(ResultSet rs, double[][] distances) throws SQLException {
         int count = 0;
         while (rs.next()) {
             final int source = rs.getInt(ST_ShortestPathLength.SOURCE_INDEX);
@@ -722,6 +726,21 @@ public class ST_ShortestPathLengthTest {
 
     private void oneToSeveral(String orientation, int source, String destinationString, double[] distances) throws SQLException {
         oneToSeveral(orientation, null, source, destinationString, distances);
+    }
+
+    @Test
+    public void edgesWithInfiniteWeights() throws Exception {
+        // SELECT * FROM ST_ShortestPathLength('inf_edges_all',
+        //     'undirected', 'source_dest')
+        final double[][] distances = {{0.0, 10.0, 5.0, 11.0, 7.0},
+                                      {10.0, 0.0, 9.0, 1.0, 7.0},
+                                      {5.0, 9.0, 0.0, 8.0, 2.0},
+                                      {11.0, 1.0, 8.0, 0.0, 6.0},
+                                      {7.0, 7.0, 2.0, 6.0, 0.0}};
+        checkManyToMany(
+                st.executeQuery("SELECT * FROM ST_ShortestPathLength('inf_edges_all', " +
+                        "'undirected', 'weight', 'source_dest')"),
+                distances);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
We set some edge weights to `POWER(0, -1)`, which is how we represent
infinity in SQL. I make sure this is interpreted as
`Double.POSITIVE_INFINITY` in Java by adding a unit test.

Setting an edge weight to infinity is equivalent to deleting it from the
graph.

@gpetit This is what you were talking about yesterday.
