### PR TITLE
Prevent ST_Reverse from converting MP -> GC

### DIFF
--- a/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/function/spatial/edit/ST_Reverse.java
+++ b/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/function/spatial/edit/ST_Reverse.java
@@ -24,12 +24,15 @@
 package org.h2gis.h2spatialext.function.spatial.edit;
 
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.MultiPoint;
+import com.vividsolutions.jts.geom.Point;
 import org.h2gis.h2spatialapi.DeterministicScalarFunction;
 
 /**
  * Returns the geometry with vertex order reversed.
  *
  * @author Erwan Bocher
+ * @author Adam Gouge
  */
 public class ST_Reverse extends DeterministicScalarFunction {
 
@@ -45,10 +48,32 @@ public class ST_Reverse extends DeterministicScalarFunction {
     /**
      * Returns the geometry with vertex order reversed.
      *
-     * @param geometry
-     * @return
+     * @param geometry Geometry
+     * @return geometry with vertex order reversed
      */
     public static Geometry reverse(Geometry geometry) {
+        if (geometry == null) {
+            return null;
+        }
+        if (geometry instanceof MultiPoint) {
+            return reverseMultiPoint((MultiPoint) geometry);
+        }
         return geometry.reverse();
+    }
+
+    /**
+     * Returns the MultiPoint with vertex order reversed. We do our own
+     * implementation here because JTS does not handle it.
+     *
+     * @param mp MultiPoint
+     * @return MultiPoint with vertex order reversed
+     */
+    public static Geometry reverseMultiPoint(MultiPoint mp) {
+        int nPoints = mp.getNumGeometries();
+        Point[] revPoints = new Point[nPoints];
+        for (int i = 0; i < nPoints; i++) {
+            revPoints[nPoints - 1 - i] = (Point) mp.getGeometryN(i).reverse();
+        }
+        return mp.getFactory().createMultiPoint(revPoints);
     }
 }

--- a/h2spatial-ext/src/test/java/org/h2gis/h2spatialext/SpatialFunctionTest.java
+++ b/h2spatial-ext/src/test/java/org/h2gis/h2spatialext/SpatialFunctionTest.java
@@ -2115,6 +2115,22 @@ public class SpatialFunctionTest {
     }
 
     @Test
+    public void test_ST_ReverseNULL() throws Exception {
+        ResultSet rs = st.executeQuery("SELECT ST_Reverse(NULL);");
+        rs.next();
+        assertGeometryEquals(null, rs.getBytes(1));
+        rs.close();
+    }
+
+    @Test
+    public void test_ST_ReverseMultiPoint() throws Exception {
+        ResultSet rs = st.executeQuery("SELECT ST_Reverse('MULTIPOINT((4 4), (1 1), (1 0), (0 3))');");
+        rs.next();
+        assertGeometryEquals("MULTIPOINT((0 3), (1 0), (1 1), (4 4))", rs.getBytes(1));
+        rs.close();
+    }
+
+    @Test
     public void test_ST_Reverse1() throws Exception {
         ResultSet rs = st.executeQuery("SELECT ST_Reverse('LINESTRING (105 353, 150 180, 300 280)'::GEOMETRY);");
         rs.next();


### PR DESCRIPTION
Before we had:

``` mysql
SELECT ST_Reverse('MULTIPOINT((4 4), (1 1), (1 0), (0 3))');
-- Answer: GEOMETRYCOLLECTION(POINT(4 4), POINT(1 1),
--                            POINT(1 0), POINT(0 3))
```

Now we have

``` mysql
SELECT ST_Reverse('MULTIPOINT((4 4), (1 1), (1 0), (0 3))');
-- Answer: MULTIPOINT((0 3), (1 0), (1 1), (4 4))
```

**Note**: This is JTS's fault.

Also return `NULL` for `NULL` input geometries.
