### PR TITLE
Unable to transfer DB created on Win to Unix machine

### DIFF
--- a/h2drivers/src/main/java/org/h2gis/drivers/DriverManager.java
+++ b/h2drivers/src/main/java/org/h2gis/drivers/DriverManager.java
@@ -90,8 +90,8 @@ public class DriverManager extends AbstractFunction implements ScalarFunction, D
             if(driverDef.getFileExt().equalsIgnoreCase(ext)) {
                 Statement st = connection.createStatement();
                 st.execute(String.format("CREATE TABLE %s COMMENT %s ENGINE %s WITH %s",
-                        TableLocation.parse(tableName, isH2).toString(isH2),StringUtils.quoteStringSQL(URIUtility.fileFromString(fileName).toURI().toString()),
-                        StringUtils.quoteJavaString(driverDef.getClassName()),StringUtils.quoteJavaString(URIUtility.fileFromString(fileName).toString())));
+                        TableLocation.parse(tableName, isH2).toString(isH2),StringUtils.quoteStringSQL(fileName),
+                        StringUtils.quoteJavaString(driverDef.getClassName()),StringUtils.quoteJavaString(fileName)));
                 st.close();
                 return;
             }

--- a/h2drivers/src/main/java/org/h2gis/drivers/file_table/FileEngine.java
+++ b/h2drivers/src/main/java/org/h2gis/drivers/file_table/FileEngine.java
@@ -31,6 +31,7 @@ import org.h2.table.Table;
 import org.h2.util.StringUtils;
 import org.h2.value.Value;
 import org.h2gis.drivers.FileDriver;
+import org.h2gis.utilities.URIUtility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +52,7 @@ public abstract class FileEngine<Driver extends FileDriver> implements TableEngi
         if(data.tableEngineParams.isEmpty()) {
             throw DbException.get(ErrorCode.FILE_NOT_FOUND_1);
         }
-        File filePath = new File(StringUtils.javaDecode(data.tableEngineParams.get(0)));
+        File filePath = URIUtility.fileFromString(StringUtils.javaDecode(data.tableEngineParams.get(0)));
         if(!filePath.exists()) {
             // Do not throw an exception as it will prevent the user from opening the database
             LOGGER.error("File not found:\n"+filePath.getAbsolutePath()+"\nThe table "+data.tableName+" will be empty.");

--- a/h2drivers/src/main/java/org/h2gis/drivers/geojson/GeoJsonWriteDriver.java
+++ b/h2drivers/src/main/java/org/h2gis/drivers/geojson/GeoJsonWriteDriver.java
@@ -33,7 +33,7 @@ import org.h2gis.utilities.TableLocation;
 
 import java.io.*;
 import java.sql.*;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.h2gis.drivers.utility.FileUtil;
@@ -197,7 +197,7 @@ public class GeoJsonWriteDriver {
      * @throws SQLException
      */
     private void cacheMetadata(ResultSetMetaData resultSetMetaData) throws SQLException {
-        cachedColumnNames = new HashMap<String, Integer>();
+        cachedColumnNames = new LinkedHashMap<String, Integer>();
         for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
             final String fieldTypeName = resultSetMetaData.getColumnTypeName(i);
             if (!fieldTypeName.equalsIgnoreCase("geometry")

--- a/h2drivers/src/main/java/org/h2gis/drivers/kml/KMLWriterDriver.java
+++ b/h2drivers/src/main/java/org/h2gis/drivers/kml/KMLWriterDriver.java
@@ -144,6 +144,14 @@ public class KMLWriterDriver {
                 }
             } catch (IOException ex) {
                 throw new SQLException(ex);
+            } finally {
+                try {
+                    if (zos != null) {
+                        zos.close();
+                    }
+                } catch (IOException ex) {
+                    throw new SQLException(ex);
+                }
             }
         }
 

--- a/h2drivers/src/test/java/org/h2gis/drivers/geojson/GeojsonImportExportTest.java
+++ b/h2drivers/src/test/java/org/h2gis/drivers/geojson/GeojsonImportExportTest.java
@@ -209,24 +209,27 @@ public class GeojsonImportExportTest {
     @Test
     public void testWriteReadGeojsonPointProperties() throws Exception {
         Statement stat = connection.createStatement();
-        stat.execute("DROP TABLE IF EXISTS TABLE_POINTS");
-        stat.execute("create table TABLE_POINTS(the_geom POINT, id INT, climat VARCHAR)");
-        stat.execute("insert into TABLE_POINTS values( 'POINT(1 2)', 1, 'bad')");
-        stat.execute("insert into TABLE_POINTS values( 'POINT(10 200)', 2, 'good')");
-        stat.execute("CALL GeoJsonWrite('target/points_properties.geojson', 'TABLE_POINTS');");
-        stat.execute("CALL GeoJsonRead('target/points_properties.geojson', 'TABLE_POINTS_READ');");
-        ResultSet res = stat.executeQuery("SELECT * FROM TABLE_POINTS_READ;");
-        res.next();
-        assertTrue(((Geometry) res.getObject(1)).equals(WKTREADER.read("POINT(1 2)")));
-        assertTrue((res.getInt(2) == 1));
-        assertTrue((res.getString(3).equals("bad")));
-        res.next();
-        assertTrue(((Geometry) res.getObject(1)).equals(WKTREADER.read("POINT(10 200)")));
-        assertTrue((res.getInt(2) == 2));
-        assertTrue((res.getString(3).equals("good")));
-        res.close();
-        stat.execute("DROP TABLE IF EXISTS TABLE_POINTS_READ");
-        stat.close();
+        try {
+            stat.execute("DROP TABLE IF EXISTS TABLE_POINTS");
+            stat.execute("create table TABLE_POINTS(the_geom POINT, id INT, climat VARCHAR)");
+            stat.execute("insert into TABLE_POINTS values( 'POINT(1 2)', 1, 'bad')");
+            stat.execute("insert into TABLE_POINTS values( 'POINT(10 200)', 2, 'good')");
+            stat.execute("CALL GeoJsonWrite('target/points_properties.geojson', 'TABLE_POINTS');");
+            stat.execute("CALL GeoJsonRead('target/points_properties.geojson', 'TABLE_POINTS_READ');");
+            ResultSet res = stat.executeQuery("SELECT * FROM TABLE_POINTS_READ;");
+            res.next();
+            assertTrue(((Geometry) res.getObject(1)).equals(WKTREADER.read("POINT(1 2)")));
+            assertTrue((res.getInt(2) == 1));
+            assertTrue((res.getString(3).equals("bad")));
+            res.next();
+            assertTrue(((Geometry) res.getObject(1)).equals(WKTREADER.read("POINT(10 200)")));
+            assertTrue((res.getInt(2) == 2));
+            assertTrue((res.getString(3).equals("good")));
+            res.close();
+        } finally {
+            stat.execute("DROP TABLE IF EXISTS TABLE_POINTS_READ");
+            stat.close();
+        }
     }
 
     @Test
@@ -415,7 +418,7 @@ public class GeojsonImportExportTest {
         stat.execute("DROP TABLE IF EXISTS TABLE_MULTILINESTRINGS_READ");
         stat.close();
     }
-    
+
     @Test
     public void testWriteReadGeojsonCRS() throws Exception {
         Statement stat = connection.createStatement();
@@ -434,7 +437,7 @@ public class GeojsonImportExportTest {
         stat.execute("DROP TABLE IF EXISTS TABLE_POINTS_READ");
         stat.close();
     }
-    
+
     @Test
     public void testWriteReadBadSRID() throws Exception {
         Statement stat = connection.createStatement();
@@ -442,7 +445,7 @@ public class GeojsonImportExportTest {
         stat.execute("create table TABLE_POINTS(the_geom POINT CHECK ST_SRID(THE_GEOM)=9999, id INT, climat VARCHAR)");
         stat.execute("insert into TABLE_POINTS values( ST_GEOMFROMTEXT('POINT(1 2)', 9999), 1, 'bad')");
         stat.execute("insert into TABLE_POINTS values( ST_GEOMFROMTEXT('POINT(10 200)',9999), 2, 'good')");
-        stat.execute("CALL GeoJsonWrite('target/points_properties.geojson', 'TABLE_POINTS');");        
+        stat.execute("CALL GeoJsonWrite('target/points_properties.geojson', 'TABLE_POINTS');");
         stat.execute("CALL GeoJsonRead('target/points_properties.geojson', 'TABLE_POINTS_READ');");
         ResultSet res = stat.executeQuery("SELECT * FROM TABLE_POINTS_READ;");
         res.next();
@@ -453,7 +456,7 @@ public class GeojsonImportExportTest {
         stat.execute("DROP TABLE IF EXISTS TABLE_POINTS_READ");
         stat.close();
     }
-    
+
     @Test
     public void testWriteReadGeojsonMixedGeometries() throws Exception {
         Statement stat = connection.createStatement();
@@ -472,6 +475,6 @@ public class GeojsonImportExportTest {
         stat.execute("DROP TABLE IF EXISTS TABLE_MIXED_READ");
         stat.close();
     }
-    
-    
+
+
 }

--- a/h2drivers/src/test/java/org/h2gis/drivers/kml/KMLImporterExporterTest.java
+++ b/h2drivers/src/test/java/org/h2gis/drivers/kml/KMLImporterExporterTest.java
@@ -65,42 +65,57 @@ public class KMLImporterExporterTest {
     public void exportKMLPoints() throws SQLException {
         Statement stat = connection.createStatement();
         File kmlFile = new File("target/kml_points.kml");
-        stat.execute("DROP TABLE IF EXISTS KML_POINTS");
-        stat.execute("create table KML_POINTS(id int primary key, the_geom POINT, response boolean)");
-        stat.execute("insert into KML_POINTS values(1, ST_Geomfromtext('POINT (2.19 47.58)', 4326), true)");
-        stat.execute("insert into KML_POINTS values(2, ST_Geomfromtext('POINT (1.06 47.59)',  4326), false)");
-        // Create a KML file
-        stat.execute("CALL KMLWrite('target/kml_points.kml', 'KML_POINTS')");
-        assertTrue(kmlFile.exists());
-        stat.close();
+        try {
+            stat.execute("DROP TABLE IF EXISTS KML_POINTS");
+            stat.execute("create table KML_POINTS(id int primary key, the_geom POINT, response boolean)");
+            stat.execute("insert into KML_POINTS values(1, ST_Geomfromtext('POINT (2.19 47.58)', 4326), true)");
+            stat.execute("insert into KML_POINTS values(2, ST_Geomfromtext('POINT (1.06 47.59)',  4326), false)");
+            // Create a KML file
+            stat.execute("CALL KMLWrite('target/kml_points.kml', 'KML_POINTS')");
+            assertTrue(kmlFile.exists());
+        } finally {
+            stat.close();
+            assertTrue(kmlFile.delete());
+            assertFalse(kmlFile.exists());
+        }
     }
 
     @Test
     public void exportKMLLineString() throws SQLException {
         Statement stat = connection.createStatement();
         File kmlFile = new File("target/kml_lineString.kml");
-        stat.execute("DROP TABLE IF EXISTS KML_LINESTRING");
-        stat.execute("create table KML_LINESTRING(id int primary key, the_geom LINESTRING)");
-        stat.execute("insert into KML_LINESTRING values(1, ST_Geomfromtext('LINESTRING (2.19 47.58,1.19 46.58)', 4326))");
-        stat.execute("insert into KML_LINESTRING values(2, ST_Geomfromtext('LINESTRING (1.06 47.59,1.19 46.58)', 4326))");
-        // Create a KML file
-        stat.execute("CALL KMLWrite('target/kml_lineString.kml', 'KML_LINESTRING')");
-        assertTrue(kmlFile.exists());        
-        stat.close();
+        try {
+            stat.execute("DROP TABLE IF EXISTS KML_LINESTRING");
+            stat.execute("create table KML_LINESTRING(id int primary key, the_geom LINESTRING)");
+            stat.execute("insert into KML_LINESTRING values(1, ST_Geomfromtext('LINESTRING (2.19 47.58,1.19 46.58)', 4326))");
+            stat.execute("insert into KML_LINESTRING values(2, ST_Geomfromtext('LINESTRING (1.06 47.59,1.19 46.58)', 4326))");
+            // Create a KML file
+            stat.execute("CALL KMLWrite('target/kml_lineString.kml', 'KML_LINESTRING')");
+            assertTrue(kmlFile.exists());
+        } finally {
+            stat.close();
+            assertTrue(kmlFile.delete());
+            assertFalse(kmlFile.exists());
+        }
     }
 
     @Test
     public void exportKMZPoints() throws SQLException {
         Statement stat = connection.createStatement();
         File kmzFile = new File("target/kml_points.kmz");
-        stat.execute("DROP TABLE IF EXISTS KML_POINTS");
-        stat.execute("create table KML_POINTS(id int primary key, the_geom POINT, response boolean)");
-        stat.execute("insert into KML_POINTS values(1, ST_Geomfromtext('POINT (2.19 47.58)',4326), true)");
-        stat.execute("insert into KML_POINTS values(2, ST_Geomfromtext('POINT (1.06 47.59)',4326), false)");
-        // Create a KMZ file
-        stat.execute("CALL KMLWrite('target/kml_points.kmz', 'KML_POINTS')");
-        assertTrue(kmzFile.exists());
-        stat.close();
+        try {
+            stat.execute("DROP TABLE IF EXISTS KML_POINTS");
+            stat.execute("create table KML_POINTS(id int primary key, the_geom POINT, response boolean)");
+            stat.execute("insert into KML_POINTS values(1, ST_Geomfromtext('POINT (2.19 47.58)',4326), true)");
+            stat.execute("insert into KML_POINTS values(2, ST_Geomfromtext('POINT (1.06 47.59)',4326), false)");
+            // Create a KMZ file
+            stat.execute("CALL KMLWrite('target/kml_points.kmz', 'KML_POINTS')");
+            assertTrue(kmzFile.exists());
+        } finally {
+            stat.close();
+            assertTrue(kmzFile.delete());
+            assertFalse(kmzFile.exists());
+        }
     }
 
     @Test
@@ -180,6 +195,9 @@ public class KMLImporterExporterTest {
             assertTrue(true);
         } finally {
             stat.close();
+            File kmzFile = new File("target/kml_points.kmz");
+            assertTrue(kmzFile.delete());
+            assertFalse(kmzFile.exists());
         }
     }
 
@@ -197,6 +215,9 @@ public class KMLImporterExporterTest {
             assertTrue(true);
         } finally {
             stat.close();
+            File kmzFile = new File("target/kml_points.kmz");
+            assertTrue(kmzFile.delete());
+            assertFalse(kmzFile.exists());
         }
     }
 
@@ -213,7 +234,7 @@ public class KMLImporterExporterTest {
         res.close();
         stat.close();
     }
-    
+
     @Test
     public void testST_AsKml2() throws SQLException {
         Statement stat = connection.createStatement();
@@ -221,11 +242,11 @@ public class KMLImporterExporterTest {
                 + "    'LINESTRING(-1.53 47.24 100, -1.51 47.22 100, -1.50 47.19 100,"
                 + "                -1.49 47.17 100)',4326), true, 2);");
         res.next();
-        assertEquals("<LineString><extrude>1</extrude><kml:altitudeMode>relativeToGround</kml:altitudeMode><coordinates>-1.53,47.24,100.0 -1.51,47.22,100.0 -1.5,47.19,100.0 -1.49,47.17,100.0</coordinates></LineString>", res.getString(1));        
+        assertEquals("<LineString><extrude>1</extrude><kml:altitudeMode>relativeToGround</kml:altitudeMode><coordinates>-1.53,47.24,100.0 -1.51,47.22,100.0 -1.5,47.19,100.0 -1.49,47.17,100.0</coordinates></LineString>", res.getString(1));
         res.close();
         stat.close();
     }
-    
+
     @Test
     public void testST_AsKml3() throws SQLException {
         Statement stat = connection.createStatement();
@@ -233,11 +254,11 @@ public class KMLImporterExporterTest {
                 + "    'LINESTRING(-1.53 47.24 100, -1.51 47.22 100, -1.50 47.19 100,"
                 + "                -1.49 47.17 100)',4326), true, 1);");
         res.next();
-        assertEquals("<LineString><extrude>1</extrude><kml:altitudeMode>clampToGround</kml:altitudeMode><coordinates>-1.53,47.24,100.0 -1.51,47.22,100.0 -1.5,47.19,100.0 -1.49,47.17,100.0</coordinates></LineString>", res.getString(1));        
+        assertEquals("<LineString><extrude>1</extrude><kml:altitudeMode>clampToGround</kml:altitudeMode><coordinates>-1.53,47.24,100.0 -1.51,47.22,100.0 -1.5,47.19,100.0 -1.49,47.17,100.0</coordinates></LineString>", res.getString(1));
         res.close();
         stat.close();
     }
-    
+
     @Test
     public void testST_AsKml4() throws SQLException {
         Statement stat = connection.createStatement();
@@ -245,11 +266,11 @@ public class KMLImporterExporterTest {
                 + "    'LINESTRING(-1.53 47.24 100, -1.51 47.22 100, -1.50 47.19 100,"
                 + "                -1.49 47.17 100)',4326), true, 4);");
         res.next();
-        assertEquals("<LineString><extrude>1</extrude><kml:altitudeMode>absolute</kml:altitudeMode><coordinates>-1.53,47.24,100.0 -1.51,47.22,100.0 -1.5,47.19,100.0 -1.49,47.17,100.0</coordinates></LineString>", res.getString(1));        
+        assertEquals("<LineString><extrude>1</extrude><kml:altitudeMode>absolute</kml:altitudeMode><coordinates>-1.53,47.24,100.0 -1.51,47.22,100.0 -1.5,47.19,100.0 -1.49,47.17,100.0</coordinates></LineString>", res.getString(1));
         res.close();
         stat.close();
     }
-    
+
     @Test
     public void testST_AsKml5() throws SQLException {
         Statement stat = connection.createStatement();
@@ -257,11 +278,11 @@ public class KMLImporterExporterTest {
                 + "    'LINESTRING(-1.53 47.24 100, -1.51 47.22 100, -1.50 47.19 100,"
                 + "                -1.49 47.17 100)',4326), true, 8);");
         res.next();
-        assertEquals("<LineString><extrude>1</extrude><gx:altitudeMode>clampToSeaFloor</gx:altitudeMode><coordinates>-1.53,47.24,100.0 -1.51,47.22,100.0 -1.5,47.19,100.0 -1.49,47.17,100.0</coordinates></LineString>", res.getString(1));        
+        assertEquals("<LineString><extrude>1</extrude><gx:altitudeMode>clampToSeaFloor</gx:altitudeMode><coordinates>-1.53,47.24,100.0 -1.51,47.22,100.0 -1.5,47.19,100.0 -1.49,47.17,100.0</coordinates></LineString>", res.getString(1));
         res.close();
         stat.close();
     }
-    
+
     @Test
     public void testST_AsKml6() throws SQLException {
         Statement stat = connection.createStatement();
@@ -269,14 +290,14 @@ public class KMLImporterExporterTest {
                 + "    'LINESTRING(-1.53 47.24 100, -1.51 47.22 100, -1.50 47.19 100,"
                 + "                -1.49 47.17 100)',4326), true, 16);");
         res.next();
-        assertEquals("<LineString><extrude>1</extrude><gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode><coordinates>-1.53,47.24,100.0 -1.51,47.22,100.0 -1.5,47.19,100.0 -1.49,47.17,100.0</coordinates></LineString>", res.getString(1));        
+        assertEquals("<LineString><extrude>1</extrude><gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode><coordinates>-1.53,47.24,100.0 -1.51,47.22,100.0 -1.5,47.19,100.0 -1.49,47.17,100.0</coordinates></LineString>", res.getString(1));
         res.close();
         stat.close();
     }
-    
-    
+
+
     @Test(expected = IllegalArgumentException.class)
-    public void testST_AsKml7() throws  Throwable {
+    public void testST_AsKml7() throws Throwable {
         Statement stat = connection.createStatement();
         try {
             stat.execute("SELECT ST_AsKml(ST_Geomfromtext("
@@ -288,7 +309,7 @@ public class KMLImporterExporterTest {
             stat.close();
         }
     }
-    
+
     @Test(expected = SQLException.class)
     public void importFileNoExist() throws SQLException, IOException {
         Statement stat = connection.createStatement();
@@ -299,9 +320,7 @@ public class KMLImporterExporterTest {
     public void importFileWithBadExtension() throws SQLException, IOException {
         Statement stat = connection.createStatement();
         File file = new File("target/area_export.blabla");
-        file.delete();
         file.createNewFile();
         stat.execute("CALL KMLRead('target/area_export.blabla', 'BLABLA')");
-        file.delete();
-    } 
+    }
 }


### PR DESCRIPTION
Hi,
I have prepared DB on Win machine and then tried to transfer it to Unix hosting machine. I found that SQL in SYS.TABLES translates directory separators to platfrom specific values even when I provide slash. It shows error in log showing that file was not found and that table will be empty (org.h2gis.drivers.file_table.FileEngine#createTable).
I think that file path should be calculated when needed and not eagerly. With patch I have fixed two failing test. First is about not closing outputstream and second is about order of columns.
Take a look, and if you will like it, you could accept it.
Thx
Ivos