### PR TITLE
H2GIS JDBC is java 6 Api only.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 jdk:
     - openjdk6
-    - oraclejdk7
-    - openjdk7
 # Do not install anything so that we can use our custom script. Instead, just
 # return true.
 install: true


### PR DESCRIPTION
Then there is no reason to try to compile with other jvm.