### PR TITLE
Speed-up extrema by not using ROI

### DIFF
--- a/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/function/spatial/raster/ST_D8FlowAccumulation.java
+++ b/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/function/spatial/raster/ST_D8FlowAccumulation.java
@@ -15,9 +15,11 @@ import org.slf4j.LoggerFactory;
 
 
 import javax.media.jai.Histogram;
+import javax.media.jai.ImageLayout;
 import javax.media.jai.JAI;
 import javax.media.jai.PlanarImage;
 import javax.media.jai.operator.ConstantDescriptor;
+import java.awt.*;
 import java.awt.image.RenderedImage;
 import java.awt.image.renderable.ParameterBlock;
 import java.io.IOException;
@@ -73,10 +75,11 @@ public class ST_D8FlowAccumulation extends DeterministicScalarFunction {
             noData = new double[] {1.,metadata.bands[0].noDataValue};
         }
         // Create initial weight of 1 in each cell
+        RenderingHints renderingHints = new RenderingHints(JAI.KEY_IMAGE_LAYOUT, new ImageLayout(flowDirection));
         RenderedImage weight = ConstantDescriptor.create((float) metadata.width, (float) metadata.height,
-                new Float[] {1.f}, null);
+                new Float[] {1.f}, renderingHints);
         RenderedImage weightAccum = ConstantDescriptor.create((float) metadata.width, (float) metadata.height,
-                new Float[] {0.f}, null);
+                new Float[] {0.f}, renderingHints);
 
         StoredImage weightBuffer = new NoBuffer(weight);
         StoredImage weightAccumBuffer = new NoBuffer(weightAccum);

--- a/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/jai/NoDataROI.java
+++ b/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/jai/NoDataROI.java
@@ -1,9 +1,0 @@
-package org.h2gis.h2spatialext.jai;
-
-import javax.media.jai.ROI;
-
-/**
- * @author Nicolas Fortin
- */
-public class NoDataROI extends ROI {
-}

--- a/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/jai/NoDataROI.java
+++ b/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/jai/NoDataROI.java
@@ -1,0 +1,9 @@
+package org.h2gis.h2spatialext.jai;
+
+import javax.media.jai.ROI;
+
+/**
+ * @author Nicolas Fortin
+ */
+public class NoDataROI extends ROI {
+}

--- a/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/jai/RangeFilterOpImage.java
+++ b/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/jai/RangeFilterOpImage.java
@@ -59,7 +59,7 @@ public class RangeFilterOpImage extends PointOpImage {
             boolean returnFilterOnMatch, ImageLayout layout, Map configuration) {
         super(source0, filter, layout, configuration, true);
         this.minMaxMatchFilter = minMaxMatchFilter;
-        this.returnFilterOnMatch = true;
+        this.returnFilterOnMatch = returnFilterOnMatch;
         if(getNumBands() != minMaxMatchFilter.length) {
             throw new IllegalArgumentException(
                     "Input image have " + getNumBands() + " bands and constant filter have " +


### PR DESCRIPTION
ROI does not handle very well the method .getAsRectangleList() used by ExtremaOP.

- Then instead of defining a ROI for Min/Max all NoData are replace by a value found in the input raster.
- Constant image use RenderingHints of georaster in order to comply with Tile size.
TODO, implement our own speed-up implementation of getAsRectangleList() as soon as vectorization will be done. Because we will use an optimized maximum rectangle creator combined with iterator (on demand). See http://www.geeksforgeeks.org/largest-rectangle-under-histogram/