### PR TITLE
Add key word for writing config file

### DIFF
--- a/doxygen/h2gis.conf
+++ b/doxygen/h2gis.conf
@@ -32,7 +32,7 @@ PROJECT_NAME           = H2GIS
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = 1.2.2
+PROJECT_NUMBER         = SOFTWAREVERSION
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer


### PR DESCRIPTION
Using `sed` command, the config file will be updated setting the right version of H2GIS documentation.