### PR TITLE
Fix Ascii driver envelope computation

### DIFF
--- a/h2drivers/src/main/java/org/h2gis/drivers/asciiGrid/AsciiGridReader.java
+++ b/h2drivers/src/main/java/org/h2gis/drivers/asciiGrid/AsciiGridReader.java
@@ -113,7 +113,7 @@ public class AsciiGridReader {
     /**
      * @return MetaData of loaded ascii grid file
      */
-    public RasterUtils.RasterMetaData getMeta() {
+    public RasterUtils.RasterMetaData getRasterMetaData() {
         double scaleX = asciiGridRaster.getCellSizeX();
         // WKB Raster is mirrored on Y plane
         double scaleY = - asciiGridRaster.getCellSizeY();
@@ -139,7 +139,7 @@ public class AsciiGridReader {
             SQLException {
         TableLocation location = TableLocation.parse(tableReference, isH2);
         try {
-            RasterUtils.RasterMetaData rmd = getMeta();
+            RasterUtils.RasterMetaData rmd = getRasterMetaData();
             StringBuilder sb = new StringBuilder();
             sb.append("create table ").append(location.toString()).append("(id serial, the_raster raster) as ");
             sb.append("select null, ");

--- a/h2drivers/src/main/java/org/h2gis/drivers/asciiGrid/AsciiGridWriter.java
+++ b/h2drivers/src/main/java/org/h2gis/drivers/asciiGrid/AsciiGridWriter.java
@@ -135,8 +135,8 @@ public class AsciiGridWriter {
         RasterUtils.RasterMetaData met = RasterUtils.RasterMetaData
                 .fetchMetaData(blob.getBinaryStream());
         AsciiGridsImageMetadata gridMetadata = new AsciiGridsImageMetadata(
-                met.width, met.height, met.scaleX, met.scaleY,
-                met.ipX, met.ipY,
+                met.width, met.height, met.scaleX, -met.scaleY,
+                met.ipX, met.ipY - ((-met.scaleY) * met.height),
                 false, isGrass, met.bands[0].noDataValue);
 
         IIOImage iIOImage = new IIOImage(wkbReader.readAsRenderedImage(wkbReader.getMinIndex(), wkbReader.getDefaultReadParam()), null, gridMetadata);

--- a/h2drivers/src/main/java/org/h2gis/drivers/asciiGrid/ST_AsciiGridRead.java
+++ b/h2drivers/src/main/java/org/h2gis/drivers/asciiGrid/ST_AsciiGridRead.java
@@ -69,18 +69,8 @@ public class ST_AsciiGridRead extends AbstractFunction implements ScalarFunction
         if (rasterFile.exists()) {
             AsciiGridReader asciiGridReader = AsciiGridReader.fetch(connection, rasterFile);
 
-            AsciiGridRaster metadataAscii = asciiGridReader.getAsciiGridRaster();
-
-            RasterUtils.RasterBandMetaData rbmd = new RasterUtils.RasterBandMetaData(metadataAscii.getNoData(), RasterUtils.PixelType.PT_64BF, true, 0);
-
-            RasterUtils.RasterMetaData rmd = new RasterUtils.RasterMetaData(RasterUtils.LAST_WKB_VERSION, 1,
-                    metadataAscii.getCellSizeX(), metadataAscii.getCellSizeY(),
-                    metadataAscii.getXllCellCoordinate(), metadataAscii.getYllCellCoordinate(),
-                    0, 0, asciiGridReader.getSrid(),
-                    metadataAscii.getNCols(), metadataAscii.getNRows(),
-                    new RasterUtils.RasterBandMetaData[]{rbmd});
             return GeoRasterRenderedImage
-                    .create(asciiGridReader.getImage(), rmd);
+                    .create(asciiGridReader.getImage(), asciiGridReader.getMeta());
         } else {
             throw new IllegalArgumentException("The file " + fileName + " doesn't exist.");
         }

--- a/h2drivers/src/main/java/org/h2gis/drivers/asciiGrid/ST_AsciiGridRead.java
+++ b/h2drivers/src/main/java/org/h2gis/drivers/asciiGrid/ST_AsciiGridRead.java
@@ -23,14 +23,12 @@
 
 package org.h2gis.drivers.asciiGrid;
 
-import it.geosolutions.imageio.plugins.arcgrid.raster.AsciiGridRaster;
 import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import org.h2.api.GeoRaster;
 import org.h2.util.GeoRasterRenderedImage;
-import org.h2.util.RasterUtils;
 import org.h2gis.h2spatialapi.AbstractFunction;
 import org.h2gis.h2spatialapi.ScalarFunction;
 import org.h2gis.utilities.URIUtility;
@@ -70,7 +68,7 @@ public class ST_AsciiGridRead extends AbstractFunction implements ScalarFunction
             AsciiGridReader asciiGridReader = AsciiGridReader.fetch(connection, rasterFile);
 
             return GeoRasterRenderedImage
-                    .create(asciiGridReader.getImage(), asciiGridReader.getMeta());
+                    .create(asciiGridReader.getImage(), asciiGridReader.getRasterMetaData());
         } else {
             throw new IllegalArgumentException("The file " + fileName + " doesn't exist.");
         }

--- a/h2drivers/src/test/java/org/h2gis/drivers/asciiGrid/AsciiGridImportExportTest.java
+++ b/h2drivers/src/test/java/org/h2gis/drivers/asciiGrid/AsciiGridImportExportTest.java
@@ -30,6 +30,8 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+
+import com.vividsolutions.jts.geom.Envelope;
 import org.h2.api.GeoRaster;
 import org.h2.util.RasterUtils;
 import org.h2.util.StringUtils;
@@ -94,11 +96,16 @@ public class AsciiGridImportExportTest {
          assertEquals(5, metaData.height);
          assertEquals(1, metaData.numBands);
          assertEquals(273987.50, metaData.ipX, 1e-2);
-         assertEquals(2224987.50, metaData.ipY, 1e-2);
+         assertEquals(2225112.5, metaData.ipY, 1e-2);
          assertEquals(25, metaData.scaleX, 1e-2);
-         assertEquals(25, metaData.scaleY, 1e-2);
+         assertEquals(-25, metaData.scaleY, 1e-2);
          assertEquals(0., metaData.skewX, 1e-6);
          assertEquals(0., metaData.skewY, 1e-6);
+         Envelope env = metaData.getEnvelope();
+         assertEquals(273987.5, env.getMinX(), 1e-2);
+         assertEquals(274237.5, env.getMaxX(), 1e-2);
+         assertEquals(2224987.5, env.getMinY(), 1e-2);
+         assertEquals(2225112.5, env.getMaxY(), 1e-2);
          
          Raster data = geoRaster.getData();
          //Test some pixel values
@@ -120,11 +127,16 @@ public class AsciiGridImportExportTest {
         GeoRaster geoRaster = (GeoRaster) rs.getObject(1);
         RasterUtils.RasterMetaData metaData = geoRaster.getMetaData();
         assertNotNull(metaData);
+        Envelope env = metaData.getEnvelope();
+        assertEquals(273987.5, env.getMinX(), 1e-2);
+        assertEquals(274237.5, env.getMaxX(), 1e-2);
+        assertEquals(2224987.5, env.getMinY(), 1e-2);
+        assertEquals(2225112.5, env.getMaxY(), 1e-2);
         assertEquals(10, metaData.width);
         assertEquals(5, metaData.height);
         assertEquals(1, metaData.numBands);
         assertEquals(273987.50, metaData.ipX, 1e-2);
-        assertEquals(2224987.50, metaData.ipY, 1e-2);
+        assertEquals(2225112.5, metaData.ipY, 1e-2);
         assertEquals(25, metaData.scaleX, 1e-2);
         assertEquals(-25, metaData.scaleY, 1e-2);
         assertEquals(0., metaData.skewX, 1e-6);
@@ -160,7 +172,7 @@ public class AsciiGridImportExportTest {
         assertEquals(5, metaData.height);
         assertEquals(1, metaData.numBands);
         assertEquals(273987.50, metaData.ipX, 1e-2);
-        assertEquals(2224987.50, metaData.ipY, 1e-2);
+        assertEquals(2225112.5, metaData.ipY, 1e-2);
         assertEquals(25, metaData.scaleX, 1e-2);
         assertEquals(-25, metaData.scaleY, 1e-2);
         assertEquals(0., metaData.skewX, 1e-6);
@@ -194,8 +206,13 @@ public class AsciiGridImportExportTest {
         assertEquals(10, metaData.width);
         assertEquals(5, metaData.height);
         assertEquals(1, metaData.numBands);
+        Envelope env = metaData.getEnvelope();
+        assertEquals(273987.5, env.getMinX(), 1e-2);
+        assertEquals(274237.5, env.getMaxX(), 1e-2);
+        assertEquals(2224987.5, env.getMinY(), 1e-2);
+        assertEquals(2225112.5, env.getMaxY(), 1e-2);
         assertEquals(273987.50, metaData.ipX, 1e-2);
-        assertEquals(2224987.50, metaData.ipY, 1e-2);
+        assertEquals(2225112.5, metaData.ipY, 1e-2);
         assertEquals(25, metaData.scaleX, 1e-2);
         assertEquals(-25, metaData.scaleY, 1e-2);
         assertEquals(0., metaData.skewX, 1e-6);


### PR DESCRIPTION
WKB Raster is upper left based and Ascii driver is lower left based. Fix the driver to place the raster at the right position.