### PR TITLE
Update homepage and configuration file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ pygments: true
 relative_permalinks: false
 permalink: /news/:year/:month/:day/:title/
 excerpt_separator: noifniof3nioaniof3nioafafinoafnoif
-repository: https://github.com/irstv/H2GIS
+repository: https://github.com/orbisgis/h2gis
 baseurl: 
 exclude: ["vendor"]
 markdown: kramdown

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ description: A spatial extension of the H2 database. Compliant, Solid, Tested.
         <div class="article"><h4>Getting started<br>couldn't be simpler.<br></h4></div>
         <div style="padding: 10px;">
             <div id="cf" style="display:inline-block">
-                <a href="https://github.com/orbisgis/h2gis/releases/download/v1.2.3/h2-dist-1.2.3-bin.zip"
+                <a href="https://github.com/orbisgis/h2gis/releases/download/v1.3.0/h2gis-dist-1.3.0-bin.zip"
                    onclick="_gaq.push(['_trackEvent','Download','h2gis-jar',this.href]);setTimeout(function(){return true;},200);">
                     <img class="bottom" src="{{ site.baseurl }}/img/download_button_hover.png" alt="Download"/>
                     <img class="top" src="{{ site.baseurl }}/img/download_button.png" alt="Download"/>


### PR DESCRIPTION
Update homepage to change the release number and update configuration file to replace irstv link with the appropriate one