### PR TITLE
H2GISVersion function

### DIFF
--- a/h2gis-functions/src/main/java/org/h2gis/functions/factory/H2GISFunctions.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/factory/H2GISFunctions.java
@@ -212,6 +212,7 @@ import org.h2gis.functions.spatial.type.GeometryTypeFromConstraint;
 import org.h2gis.functions.spatial.type.GeometryTypeNameFromConstraint;
 import org.h2gis.functions.string.HexToVarBinary;
 import org.h2gis.functions.system.DoubleRange;
+import org.h2gis.functions.system.H2GISversion;
 import org.h2gis.functions.system.IntegerRange;
 import org.h2gis.utilities.GeometryTypeCodes;
 import org.slf4j.Logger;
@@ -419,7 +420,8 @@ public class H2GISFunctions {
                 new TSVRead(),
                 new TSVWrite(),
                 new ST_NPoints(),
-                new ST_Graph()};
+                new ST_Graph(),
+                new H2GISversion()};
     }
 
     /**

--- a/h2gis-functions/src/main/java/org/h2gis/functions/system/H2GISversion.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/system/H2GISversion.java
@@ -1,0 +1,67 @@
+/**
+ * H2GIS is a library that brings spatial support to the H2 Database Engine
+ * <http://www.h2database.com>. H2GIS is developed by CNRS
+ * <http://www.cnrs.fr/>.
+ *
+ * This code is part of the H2GIS project. H2GIS is free software; 
+ * you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation;
+ * version 3.0 of the License.
+ *
+ * H2GIS is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details <http://www.gnu.org/licenses/>.
+ *
+ *
+ * For more information, please consult: <http://www.h2gis.org/>
+ * or contact directly: info_at_h2gis.org
+ */
+package org.h2gis.functions.system;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+import org.h2gis.api.DeterministicScalarFunction;
+
+/**
+ * Return the current version of H2GIS stored in the manifest
+ * 
+ * @author Erwan Bocher
+ */
+public class H2GISversion extends DeterministicScalarFunction{
+
+    
+    public H2GISversion(){
+        addProperty(PROP_REMARKS, "Returns H2GISGIS version number");
+    }
+    
+    
+    @Override
+    public String getJavaStaticMethod() {
+        return "geth2gisVersion";
+    }
+    
+    /**
+     * Return the H2GIS version available in the MANISFEST file
+     * Otherwise return unknown
+     * 
+     * @return 
+     */
+    public static String geth2gisVersion() {
+        URLClassLoader cl = (URLClassLoader) H2GISversion.class.getClassLoader();
+        try {
+            URL url = cl.findResource("META-INF/MANIFEST.MF");
+            Manifest manifest = new Manifest(url.openStream());
+            Attributes att = manifest.getMainAttributes();
+            return att.getValue("bundle-version");
+
+        } catch (IOException e) {
+            return "unknown";
+        }
+    }
+    
+    
+}

--- a/h2gis-functions/src/main/resources/org/h2gis/functions/system/version.txt
+++ b/h2gis-functions/src/main/resources/org/h2gis/functions/system/version.txt
@@ -1,0 +1,1 @@
+${project.version}

--- a/h2gis-functions/src/test/java/org/h2gis/functions/system/SystemFunctionTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/system/SystemFunctionTest.java
@@ -30,6 +30,7 @@ import org.h2gis.functions.factory.H2GISDBFactory;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import static org.junit.Assert.assertNotEquals;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -128,11 +129,11 @@ public class SystemFunctionTest {
         }
     }
     
-    //@Test
+    @Test
     public void test_H2GISVersion() throws Exception {
         ResultSet rs = st.executeQuery("SELECT H2GISVersion();");
         rs.next();
-        System.out.println("version " + rs.getString(1));
+        assertNotEquals("unknown", rs.getString(1));
         rs.close();
     }
 

--- a/h2gis-functions/src/test/java/org/h2gis/functions/system/SystemFunctionTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/system/SystemFunctionTest.java
@@ -127,5 +127,13 @@ public class SystemFunctionTest {
             throw e.getOriginalCause();
         }
     }
+    
+    @Test
+    public void test_H2GISVersion() throws Exception {
+        ResultSet rs = st.executeQuery("SELECT H2GISVersion();");
+        rs.next();
+        System.out.println("version " + rs.getString(1));
+        rs.close();
+    }
 
 }


### PR DESCRIPTION
A function to return the current H2GIS version.
The version is stored in the version.txt file. It 's stored in the /org/h2gis/functions/system/version.txt resources folder.