### PR TITLE
Prepare H2GIS 1.3.1 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.orbisgis</groupId>
     <artifactId>h2gis</artifactId>
     <packaging>pom</packaging>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.1</version>
     <name>H2GIS</name>
     <description>H2GIS is a spatial extension of the H2 database engine in the spirit of PostGIS.  It adds support for the Open Geospatial Consortium (OGC) Simple Features for SQL (SFSQL) functions.</description>
     <organization>


### PR DESCRIPTION
## Change log

**Bugs**

- Read the prj file and set the SRID from FILE_TABLE interface
- Align ST_NumInteriorRing to SQL/MM
- ST_Length works only with Line, Curve and MultiLine and MultiCurve.
- Fixes on GeoJSON driver

**Enhancements**

- ST_Graph() is now compatible with a PostGIS database
- Add ST_Expand() support distance for X and Y
- Update to JTS 1.14
- Update to H2 1.4.193
- CSV, OSM and GPX drivers support options (encoding, field separators, delete existing tables...)
- Add cancel action on the CSV driver
- ST_OSMDOWNLOADER supports a delete argument to remove the downloading file

**Features**

- H2GISversion() returns the H2GIS version
- ST_Collect() is an alias of ST_Accum()
- Add ST_NPoints() and fix ST_NumPoints() to be conform to SQL/MM
- Add TSV importer and exporter drivers and functions
- Add ST_GEOMFROMWKB()
- Add ST_RemoveRepeatedPoints() and ST_RemoveDuplicatedCoordinates()
- Add ST_MakeValid() to return a valid geometry

**Documentation**

- ST_ACCUM(), ST_Collect(), ST_NPoints(), ST_RemoveRepeatedPoints(), ST_RemoveDuplicatedCoordinates(), ST_MakeValid(), ST_Graph()
- H2 Network examples up to date