### PR TITLE
Update GeoJsonField class

### DIFF
--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonField.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonField.java
@@ -22,16 +22,28 @@ package org.h2gis.functions.io.geojson;
 
 /**
  * GeoJson fields used by the standard.
- * Some of theme will only be used by the 2008
- * specification of GeoJSON (like the field CRS
- * because RFC 7946 uses WGS 84 by default).
+ *
+ * Some of them will only be used by GeoJSON
+ * files of the 2008 specification.
+ * ("CRS", "CRS_URN_EPSG", "CRS_URN_OGC": These
+ * fields are no longer useful for the new
+ * standard RFC 7946 because it uses WGS 84
+ * by default.
+ * "LINK": link object doesn't exist in RFC 7946.)
+ *
+ * Although, these fields will be kept for
+ * compatibility reasons and indicated "2008" in
+ * comment.
+ *
+ * New field "BBOX" is added for interoperability
+ * reasons.
  * 
  * @author Erwan Bocher
  */
 public class GeoJsonField {
     
     static String NAME="name";
-    static String CRS ="crs";
+    static String CRS ="crs"; // 2008
     static String FEATURES="features";
     static String FEATURECOLLECTION="featurecollection";
     static String FEATURE="feature";
@@ -46,9 +58,9 @@ public class GeoJsonField {
     static String COORDINATES="coordinates";
     static String GEOMETRYCOLLECTION="geometrycollection";
     static String GEOMETRIES="geometries";
-    static String CRS_URN_EPSG="urn:ogc:def:crs:epsg::";
-    static String CRS_URN_OGC="urn:ogc:def:crs:ogc:1.3:";
-    static String LINK="link";
-        
+    static String CRS_URN_EPSG="urn:ogc:def:crs:epsg::"; // 2008
+    static String CRS_URN_OGC="urn:ogc:def:crs:ogc:1.3:"; // 2008
+    static String LINK="link"; // 2008
+    static String BBOX="bbox";
     
 }

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonField.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonField.java
@@ -22,6 +22,9 @@ package org.h2gis.functions.io.geojson;
 
 /**
  * GeoJson fields used by the standard.
+ * Some of theme will only be used by the 2008
+ * specification of GeoJSON (like the field CRS
+ * because RFC 7946 uses WGS 84 by default).
  * 
  * @author Erwan Bocher
  */

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonField.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonField.java
@@ -62,5 +62,5 @@ public class GeoJsonField {
     static String CRS_URN_OGC="urn:ogc:def:crs:ogc:1.3:"; // 2008
     static String LINK="link"; // 2008
     static String BBOX="bbox";
-    
+
 }

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonField.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonField.java
@@ -22,22 +22,6 @@ package org.h2gis.functions.io.geojson;
 
 /**
  * GeoJson fields used by the standard.
- *
- * Some of them will only be used by GeoJSON
- * files of the 2008 specification.
- * ("CRS", "CRS_URN_EPSG", "CRS_URN_OGC": These
- * fields are no longer useful for the new
- * standard RFC 7946 because it uses WGS 84
- * by default.
- * "LINK": link object doesn't exist in RFC 7946.)
- *
- * Although, these fields will be kept for
- * compatibility reasons and indicated "2008" in
- * comment.
- *
- * New field "BBOX" is added for interoperability
- * reasons.
- * 
  * @author Erwan Bocher
  */
 public class GeoJsonField {


### PR DESCRIPTION
Some fields will only be used by GeoJSON files of the 2008 specification.
("CRS", "CRS_URN_EPSG", "CRS_URN_OGC": These fields are no longer useful for the new standard RFC 7946 because it uses WGS 84 by default.
 "LINK": link object doesn't exist in RFC 7946.)
Although, these fields will be kept for compatibility reasons and indicated "2008" in comment.
New field "BBOX" is added for interoperability.