### PR TITLE
Fixes the warning on jenkins because of the relativePath. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,5 +108,6 @@
         <groupId>org.orbisgis</groupId>
         <artifactId>orbisgis-nexus</artifactId>
         <version>3</version>
+        <relativePath></relativePath>
     </parent>
 </project>


### PR DESCRIPTION
Fixes the warning on jenkins because of the relativePath. 