### PR TITLE
Create empty table when the file is empty

### DIFF
--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonReaderDriver.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonReaderDriver.java
@@ -129,9 +129,7 @@ public class GeoJsonReaderDriver {
             if (fileName.length() > 0) {
                 parseGeoJson(progress);
             } else {
-                try (Statement stmt = connection.createStatement()) {
-                    stmt.execute("create table " + tableLocation + "()");
-                }
+                JDBCUtilities.createEmptyTable(connection, tableLocation.toString());
             }
         }
     }

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/gpx/GPXDriverFunction.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/gpx/GPXDriverFunction.java
@@ -28,6 +28,8 @@ import org.h2gis.functions.io.gpx.model.GpxParser;
 import org.h2gis.api.DriverFunction;
 import org.h2gis.api.ProgressVisitor;
 import org.h2gis.functions.io.gpx.model.GPXTablesFactory;
+import org.h2gis.utilities.JDBCUtilities;
+import org.h2gis.utilities.TableLocation;
 
 /**
  * This class is used to read a GPX file
@@ -88,10 +90,15 @@ public class GPXDriverFunction implements DriverFunction {
      * @throws IOException File read error
      */
     public void importFile(Connection connection, String tableReference, File fileName, ProgressVisitor progress, boolean deleteTables) throws SQLException, IOException {
-        if(deleteTables){
-            GPXTablesFactory.dropOSMTables(connection, deleteTables, tableReference);
-        }        
-        GpxParser gpd = new GpxParser();
-        gpd.read(fileName, tableReference, connection);
+        boolean isH2 = JDBCUtilities.isH2DataBase(connection.getMetaData());
+        if (fileName.length() == 0) {
+            JDBCUtilities.createEmptyTable(connection, TableLocation.parse(tableReference, isH2).toString());
+        } else {
+            if (deleteTables) {
+                GPXTablesFactory.dropOSMTables(connection, isH2, tableReference);
+            }
+            GpxParser gpd = new GpxParser();
+            gpd.read(fileName, tableReference, connection);
+        }
     }
 }

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/osm/OSMDriverFunction.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/osm/OSMDriverFunction.java
@@ -99,7 +99,7 @@ public class OSMDriverFunction implements DriverFunction {
         }
         OSMParser osmp = new OSMParser();
         osmp.read(connection, tableReference, fileName, progress);
-    }
+        }
 
     @Override
     public String[] getImportFormats() {

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/osm/OSMParser.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/osm/OSMParser.java
@@ -130,22 +130,23 @@ public class OSMParser extends DefaultHandler {
             fs = new FileInputStream(inputFile);
             this.fc = fs.getChannel();
             this.fileSize = fc.size();
-            // Given the file size and an average node file size.
-            // Skip how many nodes in order to update progression at a step of 1%
-            readFileSizeEachNode = Math.max(1, (this.fileSize / AVERAGE_NODE_SIZE) / 100);
-            nodeCountProgress = 0;
-            XMLReader parser = XMLReaderFactory.createXMLReader();
-            parser.setErrorHandler(this);
-            parser.setContentHandler(this);
-            if(inputFile.getName().endsWith(".osm")) {
-                parser.parse(new InputSource(fs));
-            } else if(inputFile.getName().endsWith(".osm.gz")) {
-                parser.parse(new InputSource(new GZIPInputStream(fs)));
-            } else if(inputFile.getName().endsWith(".osm.bz2")) {
-                parser.parse(new InputSource(new BZip2CompressorInputStream(fs)));
-            }
-            else{
-                throw new SQLException("Supported formats are .osm, .osm.gz, .osm.bz2");
+            if (fileSize > 0) {
+                // Given the file size and an average node file size.
+                // Skip how many nodes in order to update progression at a step of 1%
+                readFileSizeEachNode = Math.max(1, (this.fileSize / AVERAGE_NODE_SIZE) / 100);
+                nodeCountProgress = 0;
+                XMLReader parser = XMLReaderFactory.createXMLReader();
+                parser.setErrorHandler(this);
+                parser.setContentHandler(this);
+                if (inputFile.getName().endsWith(".osm")) {
+                    parser.parse(new InputSource(fs));
+                } else if (inputFile.getName().endsWith(".osm.gz")) {
+                    parser.parse(new InputSource(new GZIPInputStream(fs)));
+                } else if (inputFile.getName().endsWith(".osm.bz2")) {
+                    parser.parse(new InputSource(new BZip2CompressorInputStream(fs)));
+                } else {
+                    throw new SQLException("Supported formats are .osm, .osm.gz, .osm.bz2");
+                }
             }
             success = true;
         } catch (SAXException ex) {

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/osm/OSMRead.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/osm/OSMRead.java
@@ -70,15 +70,16 @@ public class OSMRead extends AbstractFunction implements ScalarFunction {
      * @throws SQLException 
      */
     public static void readOSM(Connection connection, String fileName, String tableReference, boolean deleteTables) throws FileNotFoundException, SQLException, IOException {
-        if(deleteTables){
+        if (deleteTables) {
             OSMTablesFactory.dropOSMTables(connection, JDBCUtilities.isH2DataBase(connection.getMetaData()), tableReference);
-        }        
+        }
         File file = URIUtilities.fileFromString(fileName);
         if (!file.exists()) {
             throw new FileNotFoundException("The following file does not exists:\n" + fileName);
         }
         OSMDriverFunction osmdf = new OSMDriverFunction();
         osmdf.importFile(connection, tableReference, file, new EmptyProgressVisitor(), deleteTables);
+ 
     }
 
     /**

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/dbf/DBFImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/dbf/DBFImportExportTest.java
@@ -228,4 +228,33 @@ public class DBFImportExportTest {
         assertFalse(rs.next());
         rs.close();
     }
+    
+    
+    @Test
+    public void testWriteReadEmptyTable1() throws SQLException {
+        Statement stat = connection.createStatement();
+        stat.execute("DROP TABLE IF EXISTS TABLE_EMPTY");
+        stat.execute("create table TABLE_EMPTY(id INTEGER)");
+        stat.execute("CALL DBFWrite('target/empty.dbf', 'TABLE_EMPTY');");
+        stat.execute("CALL DBFRead('target/empty.dbf', 'TABLE_EMPTY_READ');");
+        ResultSet res = stat.executeQuery("SELECT * FROM TABLE_EMPTY_READ;");
+        ResultSetMetaData rsmd = res.getMetaData();
+        assertTrue(rsmd.getColumnCount()==2);
+        assertTrue(!res.next());
+        stat.close();
+    }
+    
+    @Test
+    public void testWriteReadEmptyTable2() throws SQLException {
+        Statement stat = connection.createStatement();
+        stat.execute("DROP TABLE IF EXISTS TABLE_EMPTY");
+        stat.execute("create table TABLE_EMPTY()");
+        stat.execute("CALL DBFWrite('target/empty.dbf', 'TABLE_EMPTY');");
+        stat.execute("CALL DBFRead('target/empty.dbf', 'TABLE_EMPTY_READ');");
+        ResultSet res = stat.executeQuery("SELECT * FROM TABLE_EMPTY_READ;");
+        ResultSetMetaData rsmd = res.getMetaData();
+        assertTrue(rsmd.getColumnCount()==0);
+        assertTrue(!res.next());
+        stat.close();
+    }
 }

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/geojson/GeojsonImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/geojson/GeojsonImportExportTest.java
@@ -720,7 +720,7 @@ public class GeojsonImportExportTest {
         ResultSet res = stat.executeQuery("SELECT * FROM TABLE_POINTS_READ;");
         ResultSetMetaData rsmd = res.getMetaData();
         assertTrue(rsmd.getColumnCount()==0);
-        res.next();
+        assertTrue(!res.next());
         stat.close();
     }
 }

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/geojson/GeojsonImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/geojson/GeojsonImportExportTest.java
@@ -25,9 +25,9 @@ import com.vividsolutions.jts.io.WKTReader;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import org.h2.jdbc.JdbcSQLException;
 
 import org.h2.util.StringUtils;
 import org.h2gis.functions.factory.H2GISDBFactory;
@@ -710,17 +710,17 @@ public class GeojsonImportExportTest {
         stat.close();
     }
     
-    @Test(expected = SQLException.class)
-    public void testWriteReadEmptyTable() throws Throwable {
+    @Test
+    public void testWriteReadEmptyTable() throws SQLException {
         Statement stat = connection.createStatement();
         stat.execute("DROP TABLE IF EXISTS TABLE_POINTS");
         stat.execute("create table TABLE_POINTS(the_geom POINT)");
         stat.execute("CALL GeoJsonWrite('target/points.geojson', 'TABLE_POINTS');");
-        try {
-            stat.execute("CALL GeoJsonRead('target/points.geojson', 'TABLE_POINTS_READ');");
-        } catch (JdbcSQLException e) {
-            throw e.getOriginalCause();
-        }
+        stat.execute("CALL GeoJsonRead('target/points.geojson', 'TABLE_POINTS_READ');");
+        ResultSet res = stat.executeQuery("SELECT * FROM TABLE_POINTS_READ;");
+        ResultSetMetaData rsmd = res.getMetaData();
+        assertTrue(rsmd.getColumnCount()==0);
+        res.next();
         stat.close();
     }
 }

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/tsv/TSVDriverTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/tsv/TSVDriverTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2gis.functions.factory.H2GISFunctions;
@@ -115,6 +116,18 @@ public class TSVDriverTest {
 
     }
     
-    
+    @Test
+    public void testWriteReadEmptyTable() throws SQLException {
+        Statement stat = connection.createStatement();
+        stat.execute("DROP TABLE IF EXISTS empty_table");
+        stat.execute("create table empty_table()");
+        stat.execute("CALL TSVWrite('target/empty_table.tsv', 'empty_table');");
+        stat.execute("CALL TSVRead('target/empty_table.tsv', 'empty_table_read');");
+        ResultSet res = stat.executeQuery("SELECT * FROM empty_table_read;");
+        ResultSetMetaData rsmd = res.getMetaData();
+        assertTrue(rsmd.getColumnCount()==0);
+        assertTrue(!res.next());
+        stat.close();
+    }
     
 }

--- a/h2gis-utilities/src/main/java/org/h2gis/utilities/JDBCUtilities.java
+++ b/h2gis-utilities/src/main/java/org/h2gis/utilities/JDBCUtilities.java
@@ -43,6 +43,7 @@ import java.util.List;
  * @author Adam Gouge
  */
 public class JDBCUtilities {
+
     public enum FUNCTION_TYPE { ALL, BUILT_IN, ALIAS}
     public static final String H2_DRIVER_NAME = "H2 JDBC Driver";
 
@@ -315,14 +316,11 @@ public class JDBCUtilities {
      * @throws java.sql.SQLException
      */
     public static boolean tableExists(Connection connection, String tableName) throws SQLException {
-        final Statement statement = connection.createStatement();
-        try {
+        try (Statement statement = connection.createStatement()) {
             statement.execute("SELECT * FROM " + TableLocation.parse(tableName) + " LIMIT 0;");
             return true;
         } catch (SQLException ex) {
             return false;
-        } finally {
-            statement.close();
         }
     }
 
@@ -377,6 +375,18 @@ public class JDBCUtilities {
             statement.close();
         }
         return fieldValues;
+    }
+    
+    /**
+     * A method to create an empty table (no columns)
+     * @param connection Connection
+     * @param tableReference Table name
+     * @throws java.sql.SQLException
+     */
+    public static void createEmptyTable(Connection connection, String tableReference) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE "+ tableReference+ " ()");
+        }
     }
 
     /**

--- a/h2gis-utilities/src/test/java/org/h2gis/utilities/JDBCUtilitiesTest.java
+++ b/h2gis-utilities/src/test/java/org/h2gis/utilities/JDBCUtilitiesTest.java
@@ -28,6 +28,8 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 
@@ -231,5 +233,16 @@ public class JDBCUtilitiesTest {
         statement.execute("DROP TABLE IF EXISTS LINKEDTABLE");
         statement.execute("CREATE LINKED TABLE LINKEDTABLE('org.h2.Driver', '"+databasePath+"', 'sa', '', 'TEMPTABLE');");
         assertTrue(JDBCUtilities.isLinkedTable(connection, "LINKEDTABLE"));
+    }
+    
+    @Test
+    public void testCreateEmptyTable() throws SQLException {
+        st.execute("drop table if exists emptytable");
+        JDBCUtilities.createEmptyTable(connection, "emptytable");
+        ResultSet res = st.executeQuery("SELECT * FROM emptytable;");
+        ResultSetMetaData rsmd = res.getMetaData();
+        assertTrue(rsmd.getColumnCount()==0);
+        assertTrue(!res.next());
+        st.execute("DROP TABLE emptytable");
     }
 }


### PR DESCRIPTION
To avoid interrupting the processing chains, an empty table is created when the file read by the driver is empty. 
Add unit tests