### PR TITLE
Improve the poms structure.

### DIFF
--- a/h2gis-api/pom.xml
+++ b/h2gis-api/pom.xml
@@ -1,16 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <!-- Maven Coordinates -->
     <parent>
         <artifactId>h2gis-parent</artifactId>
         <groupId>org.orbisgis</groupId>
         <version>1.5.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
+
     <artifactId>h2gis-api</artifactId>
-    <name>h2gis-api</name>
     <packaging>bundle</packaging>
+
+    <!-- Project Information -->
+    <name>h2gis-api</name>
     <description>H2GIS API define extension point of H2GIS</description>
+
     <organization>
         <name>CNRS</name>
         <url>http://www.h2gis.org</url>
@@ -22,31 +30,33 @@
             <url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
         </license>
     </licenses>
+
+    <!-- Properties -->
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <!-- Build Settings -->
     <build>
         <plugins>
+            <!-- Plugin for the bundle packaging -->
             <plugin>
-                <groupId>org.apache.felix</groupId>
+                <groupId>${maven-bundle-plugin-groupId}</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>${maven-bundle-plugin-version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
                         <Public-Package>org.h2gis.api.*</Public-Package>
+                        <Bundle-Vendor>CNRS</Bundle-Vendor>
+                        <Bundle-Category>JDBC</Bundle-Category>
                     </instructions>
                 </configuration>
             </plugin>
+            <!-- Plugin for the compilation -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <groupId>${maven-compiler-plugin-groupId}</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
 </project>

--- a/h2gis-dist/pom.xml
+++ b/h2gis-dist/pom.xml
@@ -1,14 +1,24 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
+    <!-- Maven Coordinates -->
     <parent>
         <groupId>org.orbisgis</groupId>
         <artifactId>h2gis-parent</artifactId>
         <version>1.5.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
+
     <artifactId>h2gis-dist</artifactId>
+
+    <!-- Project Information -->
     <name>h2gis-dist</name>
+    <description>Generate a jar file containing the whole H2GIS project.</description>
+
     <organization>
         <name>CNRS</name>
         <url>http://www.h2gis.org</url>
@@ -20,20 +30,65 @@
             <url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
         </license>
     </licenses>
+
+    <!-- Properties -->
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <!-- Dependencies -->
+    <dependencies>
+        <!-- Simple Logging Facade for Java -->
+        <dependency>
+            <groupId>${slf4j-groupId}</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>h2gis-osgi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>h2gis-network</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.orbisgis</groupId>
+            <artifactId>postgis-jts-osgi</artifactId>
+            <version>5.0.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.postgis</groupId>
+                    <artifactId>postgis-jdbc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.postgis</groupId>
+                    <artifactId>postgis-jdbc-jtsparser</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <!-- Build Settings -->
     <build>
         <plugins>
+            <!-- Plugin for test running -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <groupId>${maven-surfire-plugin-groupId}</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.14</version>
                 <configuration>
                     <workingDirectory>target/</workingDirectory>
                 </configuration>
             </plugin>
+            <!-- Plugin for the execution of a Java program -->
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>${exec-maven-plugin-groupId}</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
                 <configuration>
                     <executable>java</executable>
                     <classpathScope>runtime</classpathScope>
@@ -45,10 +100,10 @@
                     </arguments>
                 </configuration>
             </plugin>
+            <!-- Create a JAR from the project -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <groupId>${maven-jar-plugin-groupId}</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -59,9 +114,10 @@
                     </archive>
                 </configuration>
             </plugin>
+            <!-- Plugin for aggregate the project output with dependencies, modules, documentation and other files  -->
             <plugin>
+                <groupId>${maven-assembly-plugin-groupId}</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
                 <executions>
                     <execution>
                         <id>make-assembly</id> <!-- this is used for inheritance merges -->
@@ -81,43 +137,4 @@
             </plugin>
         </plugins>
     </build>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-    <dependencies>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${sl4j-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.orbisgis</groupId>
-            <artifactId>h2gis-osgi</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.orbisgis</groupId>
-            <artifactId>h2gis-network</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.orbisgis</groupId>
-            <artifactId>postgis-jts-osgi</artifactId>
-            <version>5.0.1</version>
-	    <exclusions>
-	      <exclusion>
-            <groupId>org.postgis</groupId>
-            <artifactId>postgis-jdbc</artifactId>
-	      </exclusion>
-	      <exclusion>
-            <groupId>org.postgis</groupId>
-            <artifactId>postgis-jdbc-jtsparser</artifactId>
-	      </exclusion>
-	      <exclusion>
-            <groupId>postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-	      </exclusion>
-	    </exclusions> 	    
-	</dependency>
-    </dependencies>
 </project>

--- a/h2gis-functions-osgi/pom.xml
+++ b/h2gis-functions-osgi/pom.xml
@@ -1,58 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.orbisgis</groupId>
-		<artifactId>h2gis-parent</artifactId>
-		<version>1.5.0-SNAPSHOT</version>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Maven Coordinates -->
+    <parent>
+        <groupId>org.orbisgis</groupId>
+        <artifactId>h2gis-parent</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
-	</parent>
-	<artifactId>h2gis-osgi</artifactId>
-        <name>h2gis-functions-osgi</name>
-        <description>Register H2GIS functions when a DataSource is declared as OSGi services</description>
-        <packaging>bundle</packaging>
-        <organization>
-            <name>CNRS</name>
-            <url>http://www.h2gis.org</url>
-        </organization>
-        <url>http://github.com/orbisgis/H2GIS</url>
-        <licenses>
-            <license>
-                <name>GNU Lesser General Public License (LGPLV3+)</name>
-                <url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
-            </license>
-        </licenses>
-	<dependencies>
+    </parent>
+
+    <artifactId>h2gis-osgi</artifactId>
+    <packaging>bundle</packaging>
+
+    <!-- Project Information -->
+    <name>h2gis-functions-osgi</name>
+    <description>Register H2GIS functions when a DataSource is declared as OSGi services</description>
+
+    <organization>
+        <name>CNRS</name>
+        <url>http://www.h2gis.org</url>
+    </organization>
+    <url>http://github.com/orbisgis/H2GIS</url>
+    <licenses>
+        <license>
+            <name>GNU Lesser General Public License (LGPLV3+)</name>
+            <url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
+        </license>
+    </licenses>
+
+    <!-- Dependencies -->
+    <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>h2gis</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!-- Provided dependencies -->
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.enterprise</artifactId>
-            <version>5.0.0</version>
+            <artifactId>org.osgi.compendium</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
-            <version>${osgi-core-version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
-            <version>${org.osgi.compendium-version}</version>
+            <artifactId>org.osgi.enterprise</artifactId>
             <scope>provided</scope>
         </dependency>
-	</dependencies>
-	<build>
-		<plugins>
+    </dependencies>
+
+    <!-- Build Settings -->
+    <build>
+        <plugins>
+            <!-- Plugin for the bundle packaging -->
             <plugin>
-                <groupId>org.apache.felix</groupId>
+                <groupId>${maven-bundle-plugin-groupId}</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -63,21 +74,11 @@
                     </instructions>
                 </configuration>
             </plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-				</configuration>
-			</plugin>
-		</plugins>
-		<extensions>
-			<extension>
-				<groupId>org.apache.maven.wagon</groupId> 
-				<artifactId>wagon-ssh</artifactId> 
-				<version>2.2</version> 
-			</extension> 
-		</extensions>
-	</build>
+            <!-- Plugin for the compilation -->
+            <plugin>
+                <groupId>${maven-compiler-plugin-groupId}</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/h2gis-functions/pom.xml
+++ b/h2gis-functions/pom.xml
@@ -1,16 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.orbisgis</groupId>
-    <artifactId>h2gis-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
-  </parent>
-  <artifactId>h2gis</artifactId>
-  <name>h2gis-functions</name>
-  <packaging>bundle</packaging>
-  <organization>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Maven Coordinates -->
+    <parent>
+        <groupId>org.orbisgis</groupId>
+        <artifactId>h2gis-parent</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>h2gis</artifactId>
+    <packaging>bundle</packaging>
+
+    <!-- Project Information -->
+    <name>h2gis-functions</name>
+    <description>Main module of the H2GIS distribution. It extends H2 by adding spatial storage and analysis
+        capabilities.</description>
+
+    <organization>
         <name>CNRS</name>
         <url>http://www.h2gis.org</url>
     </organization>
@@ -21,176 +31,159 @@
             <url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
         </license>
     </licenses>
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>cts</artifactId>
-      <version>${cts-version}</version>
-      <!-- https://github.com/orbisgis/CTS -->
-    </dependency>
-    <dependency>
-      <groupId>org.orbisgis.jts</groupId>
-      <artifactId>jts-core</artifactId>
-      <version>${jts-core-version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${h2-package}</groupId>
-      <artifactId>h2</artifactId>
-      <version>${h2-version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.enterprise</artifactId>
-      <version>5.0.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-      <version>${osgi-core-version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.compendium</artifactId>
-      <version>${org.osgi.compendium-version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>h2gis-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>h2gis-utilities</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>${sl4j-version}</version>
-      <scope>test</scope>
-    </dependency>
-      <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>h2gis-test-utilities</artifactId>
-          <version>${project.version}</version>
-          <scope>test</scope>
-      </dependency>
-       <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>poly2tri-core</artifactId>
-            <version>0.1.2</version>
-        </dependency>
+
+    <!-- Properties -->
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <!-- Dependencies -->
+    <dependencies>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.3.1</version>
-        </dependency>
-        <dependency>
-            <!-- Open osm.bz2 files -->
-            <groupId>org.apache.commons</groupId>
+            <groupId>${commons-compress-groupId}</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.9</version>
-        </dependency>        
+        </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
+            <groupId>${cts-groupId}</groupId>
+            <artifactId>cts</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${h2-groupId}</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>h2gis-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>h2gis-utilities</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${jackson-core-groupId}</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${jts-core-groupId}</groupId>
+            <artifactId>jts-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${poly2tri-groupId}</groupId>
+            <artifactId>poly2tri-core</artifactId>
+        </dependency>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>${osgi-enterprise-groupId}</groupId>
+            <artifactId>org.osgi.enterprise</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${osgi-compendium-groupId}</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${osgi-core-groupId}</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>${commons-io-groupId}</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.3.2</version>
             <scope>test</scope>
         </dependency>
-  </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Export-Package>org.h2gis.functions.*</Export-Package>
-            <Fragment-Host>org.h2</Fragment-Host>    <!-- ;bundle-version=${h2-osgi-version} -->
-            <Bundle-Vendor>CNRS</Bundle-Vendor>
-            <Bundle-Category>JDBC</Bundle-Category>
-              <Import-Package>
-                  org.h2.api,
-                  org.h2.tools,
-                  org.h2.util,
-                  !org.h2.command,
-                  !org.h2.command.ddl,
-                  !org.h2.engine,
-                  !org.h2.expression,
-                  !org.h2.index,
-                  !org.h2.message,
-                  !org.h2.result,
-                  !org.h2.schema,
-                  !org.h2.table,
-                  !org.h2.*,*
-              </Import-Package>
-          </instructions>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-        <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>cobertura-maven-plugin</artifactId>
-            <version>2.6</version>
-            <configuration>
-                <check>
-                    <!-- TODO Raise Coverage constraint -->
-                    <branchRate>0</branchRate>
-                    <lineRate>0</lineRate>
-                    <haltOnFailure>true</haltOnFailure>
-                    <totalBranchRate>50</totalBranchRate>
-                    <totalLineRate>77</totalLineRate>
-                    <packageLineRate>0</packageLineRate>
-                    <packageBranchRate>0</packageBranchRate>
-                </check>
-            </configuration>
-            <executions>
-                <execution>
-                    <goals>
-                        <goal>check</goal>
-                    </goals>
-                </execution>
-            </executions>
-        </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.15</version>
-      </plugin>
-    </plugins>    
-    <resources>
-        <resource>
-            <directory>src/main/resources</directory>
-            <filtering>true</filtering>
-            <includes>
-                <include>**/version.txt</include>
-            </includes>
-        </resource>
-        <resource>
-            <directory>src/main/resources</directory>
-            <filtering>false</filtering>
-            <excludes>
-                <exclude>**/version.txt</exclude>
-            </excludes>
-        </resource>
-    </resources>
-  </build>
+        <dependency>
+            <groupId>${junit-groupId}</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>h2gis-test-utilities</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${slf4j-groupId}</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <!-- Build Settings -->
+    <build>
+        <plugins>
+            <!-- Plugin for the bundle packaging -->
+            <plugin>
+                <groupId>${maven-bundle-plugin-groupId}</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>org.h2gis.functions.*</Export-Package>
+                        <Fragment-Host>org.h2</Fragment-Host>
+                        <Bundle-Vendor>CNRS</Bundle-Vendor>
+                        <Bundle-Category>JDBC</Bundle-Category>
+                        <Import-Package>
+                            org.h2.api,
+                            org.h2.tools,
+                            org.h2.util,
+                            !org.h2.*,*
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <!-- Plugin for the test coverage check -->
+            <plugin>
+                <groupId>${cobertura-maven-plugin-groupId}</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <configuration>
+                    <check>
+                        <!-- TODO Raise Coverage constraint -->
+                        <branchRate>0</branchRate>
+                        <lineRate>0</lineRate>
+                        <haltOnFailure>true</haltOnFailure>
+                        <totalBranchRate>50</totalBranchRate>
+                        <totalLineRate>77</totalLineRate>
+                        <packageLineRate>0</packageLineRate>
+                        <packageBranchRate>0</packageBranchRate>
+                    </check>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Plugin for the compilation -->
+            <plugin>
+                <groupId>${maven-compiler-plugin-groupId}</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/version.txt</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>**/version.txt</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    </build>
 </project>

--- a/h2gis-network/pom.xml
+++ b/h2gis-network/pom.xml
@@ -1,16 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <!-- Maven Coordinates -->
     <parent>
         <artifactId>h2gis-parent</artifactId>
         <groupId>org.orbisgis</groupId>
         <version>1.5.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
+
     <artifactId>h2gis-network</artifactId>
-    <name>h2gis-network</name>
     <packaging>bundle</packaging>
+
+    <!-- Project Information -->
+    <name>h2gis-network</name>
     <description>Graph functions</description>
+
     <organization>
         <name>CNRS</name>
         <url>http://www.h2gis.org</url>
@@ -22,12 +30,68 @@
             <url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
         </license>
     </licenses>
+
+    <!-- Properties -->
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <!-- Dependencies -->
+    <dependencies>
+        <dependency>
+            <groupId>${h2-groupId}</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>h2gis</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>h2gis-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>h2gis-utilities</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${java-network-analyzer-groupId}</groupId>
+            <artifactId>java-network-analyzer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${slf4j-groupId}</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>${junit-groupId}</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>h2gis-test-utilities</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${slf4j-groupId}</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <!-- Build Settings -->
     <build>
         <plugins>
+            <!-- Plugin for the bundle packaging -->
             <plugin>
-                <groupId>org.apache.felix</groupId>
+                <groupId>${maven-bundle-plugin-groupId}</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -36,10 +100,10 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <!-- Plugin for the test coverage check -->
             <plugin>
-               <groupId>org.codehaus.mojo</groupId>
+               <groupId>${cobertura-maven-plugin-groupId}</groupId>
                <artifactId>cobertura-maven-plugin</artifactId>
-               <version>2.6</version>
                <configuration>
                    <check>
                        <lineRate>0</lineRate>
@@ -59,73 +123,16 @@
                    </execution>
                </executions>
            </plugin>
+            <!-- Plugin for test running -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <groupId>${maven-surefire-plugin-groupId}</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.15</version>
             </plugin>
+            <!-- Plugin for the compilation -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <groupId>${maven-compiler-plugin-groupId}</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-    <dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>h2gis</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>h2gis-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>h2gis-test-utilities</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${sl4j-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${sl4j-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>h2gis-utilities</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.orbisgis</groupId>
-            <artifactId>java-network-analyzer</artifactId>
-            <version>0.1.6</version>
-        </dependency>
-        <dependency>
-            <groupId>${h2-package}</groupId>
-            <artifactId>h2</artifactId>
-            <version>${h2-version}</version>
-        </dependency>
-    </dependencies>
 </project>

--- a/h2gis-test-utilities/pom.xml
+++ b/h2gis-test-utilities/pom.xml
@@ -1,19 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Maven Coordinates -->
     <parent>
         <artifactId>h2gis-parent</artifactId>
         <groupId>org.orbisgis</groupId>
         <version>1.5.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
     <artifactId>h2gis-test-utilities</artifactId>
+    <packaging>jar</packaging>
+
+    <!-- Project Information -->
     <name>h2gis-test-utilities</name>
     <description>Common class for Spatial JUnit Test</description>
-    <packaging>jar</packaging>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+
     <organization>
         <name>CNRS</name>
         <url>http://www.h2gis.org</url>
@@ -25,34 +30,36 @@
             <url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
         </license>
     </licenses>
+
+    <!-- Properties -->
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <!-- Dependencies -->
+    <dependencies>
+        <dependency>
+            <groupId>${junit-groupId}</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${h2-groupId}</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${jts-core-groupId}</groupId>
+            <artifactId>jts-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <!-- Build Settings -->
     <build>
         <plugins>
+            <!-- Plugin for the compilation -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <groupId>${maven-compiler-plugin-groupId}</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${h2-package}</groupId>
-            <artifactId>h2</artifactId>
-            <version>${h2-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.orbisgis.jts</groupId>
-            <artifactId>jts-core</artifactId>
-            <version>${jts-core-version}</version>
-        </dependency>
-    </dependencies>
 </project>

--- a/h2gis-utilities/pom.xml
+++ b/h2gis-utilities/pom.xml
@@ -1,18 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <!-- Maven Coordinates -->
     <parent>
         <artifactId>h2gis-parent</artifactId>
         <groupId>org.orbisgis</groupId>
         <version>1.5.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
+
     <name>h2gis-utilities</name>
-    <artifactId>h2gis-utilities</artifactId>
     <packaging>bundle</packaging>
+
+    <!-- Project Information -->
+    <artifactId>h2gis-utilities</artifactId>
     <description>Collection of methods to fetch spatial metadata in SFS database like PostGIS or H2GIS.
         Theses functions can be commonly used either in PostGIS or in H2.
-        Spatial utilities publish also a DataSourceFactory wrapper that provide JDBC Wrapper for spatial functionality.</description>
+        Spatial utilities publish also a DataSourceFactory wrapper that provide JDBC Wrapper for spatial
+        functionality.
+    </description>
+
     <organization>
         <name>CNRS</name>
         <url>http://www.h2gis.org</url>
@@ -24,12 +34,65 @@
             <url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
         </license>
     </licenses>
-        <build>
+
+    <!-- Properties -->
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <!-- Dependencies -->
+    <dependencies>
+        <dependency>
+            <groupId>${jts-core-groupId}</groupId>
+            <artifactId>jts-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${h2-groupId}</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>h2gis-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${slf4j-groupId}</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>${junit-groupId}</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>h2gis-test-utilities</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <!-- Build Settings -->
+    <build>
         <plugins>
+            <!-- Plugin for the bundle packaging -->
             <plugin>
-                <groupId>org.apache.felix</groupId>
+                <groupId>${maven-bundle-plugin-groupId}</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -38,10 +101,10 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <!-- Plugin for the test coverage check -->
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>${cobertura-maven-plugin-groupId}</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
                 <configuration>
                     <check>
                         <!-- TODO Raise Coverage constraint -->
@@ -72,60 +135,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Plugin for test running -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <groupId>${maven-surefire-plugin-groupId}</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.15</version>
             </plugin>
         </plugins>
     </build>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-    <dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>h2gis-test-utilities</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.orbisgis.jts</groupId>
-            <artifactId>jts-core</artifactId>
-            <version>${jts-core-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>h2gis-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
-            <version>${org.osgi.compendium-version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${h2-package}</groupId>
-            <artifactId>h2</artifactId>
-            <version>${h2-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${sl4j-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${sl4j-version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.orbisgis</groupId>
+
+    <!-- Maven Coordinates -->
+    <parent>
+        <groupId>org.orbisgis</groupId>
+        <artifactId>orbisgis-nexus</artifactId>
+        <version>3</version>
+    </parent>
+
     <artifactId>h2gis-parent</artifactId>
-    <packaging>pom</packaging>
     <version>1.5.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <!-- Project Information -->
     <name>H2GIS</name>
-    <description>H2GIS is a spatial extension of the H2 database engine in the spirit of PostGIS.  It adds support for the Open Geospatial Consortium (OGC) Simple Features for SQL (SFSQL) functions.</description>
+    <description>H2GIS is a spatial extension of the H2 database engine in the spirit of PostGIS. It adds support for
+        the Open Geospatial Consortium (OGC) Simple Features for SQL (SFSQL) functions.</description>
+
     <organization>
         <name>CNRS</name>
         <url>http://www.h2gis.org</url>
@@ -18,6 +31,195 @@
             <url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
         </license>
     </licenses>
+
+    <developers>
+        <developer>
+            <name>Nicolas Fortin</name>
+            <organization>Laboratoire d’Acoustique Environnementale (LAE) - IFSTTAR</organization>
+        </developer>
+        <developer>
+            <name>Erwan Bocher</name>
+            <organization>CNRS, Lab-STICC UMR 6285</organization>
+        </developer>
+        <developer>
+            <name>Sylvain Palominos</name>
+            <organization>UBS, Lab-STICC UMR 6285</organization>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/orbisgis/H2GIS.git</connection>
+        <developerConnection>scm:git:https://github.com/orbisgis/H2GIS.git</developerConnection>
+        <url>git@github.com:orbisgis/H2GIS.git</url>
+    </scm>
+
+    <!-- Properties -->
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <stagingDirectory>${project.build.directory}/staging/${project.version}</stagingDirectory>
+
+        <!-- Dependency groupId and version -->
+        <!-- Plugin for the test coverage check -->
+        <cobertura-maven-plugin-groupId>org.codehaus.mojo</cobertura-maven-plugin-groupId>
+        <cobertura-maven-plugin-version>2.6</cobertura-maven-plugin-version>
+
+        <commons-compress-groupId>org.apache.commons</commons-compress-groupId>
+        <commons-compress-version>1.9</commons-compress-version>
+
+        <commons-io-groupId>commons-io</commons-io-groupId>
+        <commons-io-version>1.3.2</commons-io-version>
+
+        <cts-groupId>org.orbisgis</cts-groupId>
+        <cts-version>1.4.0</cts-version>
+
+        <!-- Plugin for the execution of a Java program -->
+        <exec-maven-plugin-groupId>org.codehaus.mojo</exec-maven-plugin-groupId>
+        <exec-maven-plugin-version>1.2.1</exec-maven-plugin-version>
+
+        <h2-groupId>org.orbisgis</h2-groupId>
+        <h2-version>1.4.198</h2-version>
+
+        <jackson-core-groupId>com.fasterxml.jackson.core</jackson-core-groupId>
+        <jackson-core-version>2.3.1</jackson-core-version>
+
+        <java-network-analyzer-groupId>org.orbisgis</java-network-analyzer-groupId>
+        <java-network-analyzer-version>0.1.6</java-network-analyzer-version>
+
+        <jts-core-groupId>org.orbisgis.jts</jts-core-groupId>
+        <jts-core-version>1.15.1</jts-core-version>
+
+        <junit-groupId>junit</junit-groupId>
+        <junit-version>4.12</junit-version>
+
+        <!-- Plugin for aggregate the project output with dependencies, modules, documentation and other files  -->
+        <maven-assembly-plugin-groupId>org.apache.maven.plugins</maven-assembly-plugin-groupId>
+        <maven-assembly-plugin-version>2.3</maven-assembly-plugin-version>
+
+        <!-- Plugin for the bundle packaging -->
+        <maven-bundle-plugin-groupId>org.apache.felix</maven-bundle-plugin-groupId>
+        <maven-bundle-plugin-version>2.3.7</maven-bundle-plugin-version>
+
+        <!-- Plugin for the compilation -->
+        <maven-compiler-plugin-groupId>org.apache.maven.plugins</maven-compiler-plugin-groupId>
+        <maven-compiler-plugin-version>2.3.2</maven-compiler-plugin-version>
+
+        <!-- Create a JAR from the project -->
+        <maven-jar-plugin-groupId>org.apache.maven.plugins</maven-jar-plugin-groupId>
+        <maven-jar-plugin-version>2.4</maven-jar-plugin-version>
+
+        <!-- Plugin for test running -->
+        <maven-surefire-plugin-groupId>org.apache.maven.plugins</maven-surefire-plugin-groupId>
+        <maven-surefire-plugin-version>2.14</maven-surefire-plugin-version>
+
+        <osgi-compendium-groupId>org.osgi</osgi-compendium-groupId>
+        <osgi-compendium-version>4.3.1</osgi-compendium-version>
+
+        <osgi-core-groupId>org.osgi</osgi-core-groupId>
+        <osgi-core-version>4.3.1</osgi-core-version>
+
+        <osgi-enterprise-groupId>org.osgi</osgi-enterprise-groupId>
+        <osgi-enterprise-version>5.0.0</osgi-enterprise-version>
+
+        <poly2tri-groupId>org.orbisgis</poly2tri-groupId>
+        <poly2tri-version>0.1.2</poly2tri-version>
+
+        <!-- Simple Logging Facade for Java -->
+        <slf4j-groupId>org.slf4j</slf4j-groupId>
+        <slf4j-version>1.6.0</slf4j-version>
+    </properties>
+
+    <!-- Dependencies -->
+    <repositories>
+        <repository>
+            <id>osgi-maven-5.1</id>
+            <url>http://nexus.orbisgis.org/content/repositories/osgi-maven-5.1</url>
+        </repository>
+        <repository>
+            <id>osgi-maven-5.1-snapshot</id>
+            <url>http://nexus.orbisgis.org/content/repositories/osgi-maven-5.1-snapshot</url>
+        </repository>
+    </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${commons-compress-groupId}</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons-compress-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${cts-groupId}</groupId>
+                <artifactId>cts</artifactId>
+                <version>${cts-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${h2-groupId}</groupId>
+                <artifactId>h2</artifactId>
+                <version>${h2-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${jackson-core-groupId}</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${java-network-analyzer-groupId}</groupId>
+                <artifactId>java-network-analyzer</artifactId>
+                <version>${java-network-analyzer-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${jts-core-groupId}</groupId>
+                <artifactId>jts-core</artifactId>
+                <version>${jts-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${junit-groupId}</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${poly2tri-groupId}</groupId>
+                <artifactId>poly2tri-core</artifactId>
+                <version>${poly2tri-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${slf4j-groupId}</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j-version}</version>
+            </dependency>
+
+            <!-- Provided dependencies -->
+            <dependency>
+                <groupId>${osgi-compendium-groupId}</groupId>
+                <artifactId>org.osgi.compendium</artifactId>
+                <version>${osgi-compendium-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${osgi-core-groupId}</groupId>
+                <artifactId>org.osgi.core</artifactId>
+                <version>${osgi-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${osgi-enterprise-groupId}</groupId>
+                <artifactId>org.osgi.enterprise</artifactId>
+                <version>${osgi-enterprise-version}</version>
+            </dependency>
+
+            <!-- Test dependencies -->
+            <dependency>
+                <groupId>${commons-io-groupId}</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${slf4j-groupId}</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${slf4j-version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <!-- Build Settings -->
     <modules>
         <module>h2gis-utilities</module>
         <module>h2gis-api</module>
@@ -26,26 +228,7 @@
         <module>h2gis-network</module>
         <module>h2gis-functions-osgi</module>
     </modules>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <stagingDirectory>${project.build.directory}/staging/${project.version}</stagingDirectory>
 
-        <!-- Dependency versions -->
-        <maven-bundle-plugin-version>2.3.7</maven-bundle-plugin-version>
-        <osgi-core-version>4.3.1</osgi-core-version>
-        <h2-version>1.4.198</h2-version>
-        <h2-package>org.orbisgis</h2-package>
-        <org.osgi.compendium-version>4.3.1</org.osgi.compendium-version>
-        <jts-core-version>1.15.1</jts-core-version>
-        <sl4j-version>1.6.0</sl4j-version>
-        <cts-version>1.4.0</cts-version>
-        <junit-version>4.12</junit-version>
-    </properties>
-    <scm>
-        <connection>scm:git:https://github.com/orbisgis/H2GIS.git</connection>
-        <developerConnection>scm:git:https://github.com/orbisgis/H2GIS.git</developerConnection>
-        <url>git@github.com:orbisgis/H2GIS.git</url>
-    </scm>
     <profiles>
         <profile>
             <id>standalone</id>
@@ -54,20 +237,69 @@
             </modules>
         </profile>
     </profiles>
+
     <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Plugin for the test coverage check -->
+                <plugin>
+                    <groupId>${cobertura-maven-plugin-groupId}</groupId>
+                    <artifactId>cobertura-maven-plugin</artifactId>
+                    <version>${cobertura-maven-plugin-version}</version>
+                </plugin>
+                <!-- Plugin for the execution of a Java program -->
+                <plugin>
+                    <groupId>${exec-maven-plugin-groupId}</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${exec-maven-plugin-version}</version>
+                </plugin>
+                <!-- Plugin for aggregate the project output with dependencies, modules, documentation and other files  -->
+                <plugin>
+                    <groupId>${maven-assembly-plugin-groupId}</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${maven-assembly-plugin-version}</version>
+                </plugin>
+                <!-- Plugin for the bundle packaging -->
+                <plugin>
+                    <groupId>${maven-bundle-plugin-groupId}</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>${maven-bundle-plugin-version}</version>
+                </plugin>
+                <!-- Plugin for the compilation -->
+                <plugin>
+                    <groupId>${maven-compiler-plugin-groupId}</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin-version}</version>
+                    <configuration>
+                        <source>1.7</source>
+                        <target>1.7</target>
+                    </configuration>
+                </plugin>
+                <!-- Create a JAR from the project -->
+                <plugin>
+                    <groupId>${maven-jar-plugin-groupId}</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin-version}</version>
+                </plugin>
+                <!-- Plugin for test running -->
+                <plugin>
+                    <groupId>${maven-surefire-plugin-groupId}</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin-version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
+            <!-- Plugin for the compilation -->
             <plugin>
+                <groupId>${maven-compiler-plugin-groupId}</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
+            <!-- Create a JAR from the project -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <groupId>${maven-jar-plugin-groupId}</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -82,46 +314,5 @@
             </plugin>
         </plugins>
     </build>
-    <developers>
-        <developer>
-            <name>Nicolas Fortin</name>
-            <organization>Laboratoire d’Acoustique Environnementale (LAE) - IFSTTAR</organization>
-        </developer>
-        <developer>
-            <name>Erwan Bocher</name>
-            <organization>CNRS, Lab-STICC UMR 6285</organization>
-        </developer>
-        <developer>
-            <name>Sylvain Palominos</name>
-            <organization>CNRS, Lab-STICC UMR 6285</organization>
-        </developer>
-    </developers>
-    <parent>
-        <groupId>org.orbisgis</groupId>
-        <artifactId>orbisgis-nexus</artifactId>
-        <version>3</version>
-        <relativePath></relativePath>
-    </parent>
-    <repositories>
-        <repository>
-            <id>locationtech-releases</id>
-            <url>https://repo.locationtech.org/content/groups/releases</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>repo2.maven.org</id>
-            <name>Maven2 repository 2</name>
-            <url>http://repo2.maven.org/maven2</url>
-        </repository>
-        <repository>
-            <id>osgi-maven-5.1</id>
-            <url>http://nexus.orbisgis.org/content/repositories/osgi-maven-5.1</url>
-        </repository>
-        <repository>
-            <id>osgi-maven-5.1-snapshot</id>
-            <url>http://nexus.orbisgis.org/content/repositories/osgi-maven-5.1-snapshot</url>
-        </repository>
-    </repositories>
+
 </project>


### PR DESCRIPTION
Improve the poms structure to simplify how the dependencies and plugins are managed.
The parent pom now have a `<dependencyManagement>` and a `<pluginManagement>` tag to declare a dependency or a plugin for all the modules so then do not have to set the _version_ for the dependencies an the _configuration_ for the plugins.
All the `<groupId>` and `<version>` of the dependencies and plugin are set as variable in the `<properties>` tag.

The poms also have now all the same structure : 
``` xml
<?xml version="1.0" encoding="UTF-8"?>
<project ...>
    <modelVersion>4.0.0</modelVersion>

    <!-- Maven Coordinates -->
    <parent>... </parent>

    <artifactId>...</artifactId>
    <packaging>...</packaging>

    <!-- Project Information -->
    <name>...</name>
    <description>...</description>

    <organization>... </organization>
    <url>...</url>
    <licenses>... </licenses>

    <developers>....</developers>

    <scm>....</scm>

    <!-- Properties -->
    <properties>....</properties>

    <!-- Dependencies -->
    <repositories>...</repositories>
    <dependencyManagement>....</dependencyManagement>
    <dependencies>...</dependencies>

    <!-- Build Settings -->
    <modules>....</modules>

    <profiles>....</profiles>

    <build>
        <plugins>...</plugins>

        <resources>...</resources>
    </build>
</project>
```