### PR TITLE
Improve OSM reader

### DIFF
--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/osm/OSMImportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/osm/OSMImportTest.java
@@ -68,11 +68,11 @@ public class OSMImportTest {
 
     @Test
     public void importBz2OSMFile() throws SQLException {
-        st.execute("DROP TABLE IF EXISTS OSM_TAG, OSM_NODE, OSM_NODE_TAG, OSM_WAY,OSM_WAY_TAG, OSM_WAY_NODE, OSM_RELATION, OSM_RELATION_TAG, OSM_NODE_MEMBER, OSM_WAY_MEMBER, OSM_RELATION_MEMBER;");
+        st.execute("DROP TABLE IF EXISTS OSM_NODE, OSM_NODE_TAG, OSM_WAY,OSM_WAY_TAG, OSM_WAY_NODE, OSM_RELATION, OSM_RELATION_TAG, OSM_NODE_MEMBER, OSM_WAY_MEMBER, OSM_RELATION_MEMBER;");
         st.execute("CALL OSMRead(" + StringUtils.quoteStringSQL(OSMImportTest.class.getResource("saint_jean.osm.bz2").getPath()) + ", 'OSM');");
         ResultSet rs = st.executeQuery("SELECT count(TABLE_NAME) FROM INFORMATION_SCHEMA.TABLES where TABLE_NAME LIKE 'OSM%'");
         rs.next();
-        assertTrue(rs.getInt(1) == 11);
+        assertTrue(rs.getInt(1) == 10);
         rs.close();
         // Check number
         rs = st.executeQuery("SELECT count(ID_NODE) FROM OSM_NODE");
@@ -114,11 +114,11 @@ public class OSMImportTest {
 
     @Test
     public void importGzipOSMFile() throws SQLException {
-        st.execute("DROP TABLE IF EXISTS OSM_TAG, OSM_NODE, OSM_NODE_TAG, OSM_WAY,OSM_WAY_TAG, OSM_WAY_NODE, OSM_RELATION, OSM_RELATION_TAG, OSM_NODE_MEMBER, OSM_WAY_MEMBER, OSM_RELATION_MEMBER;");
+        st.execute("DROP TABLE IF EXISTS  OSM_NODE, OSM_NODE_TAG, OSM_WAY,OSM_WAY_TAG, OSM_WAY_NODE, OSM_RELATION, OSM_RELATION_TAG, OSM_NODE_MEMBER, OSM_WAY_MEMBER, OSM_RELATION_MEMBER;");
         st.execute("CALL OSMRead(" + StringUtils.quoteStringSQL(OSMImportTest.class.getResource("saint_jean.osm.gz").getPath()) + ", 'OSM');");
         ResultSet rs = st.executeQuery("SELECT count(TABLE_NAME) FROM INFORMATION_SCHEMA.TABLES where TABLE_NAME LIKE 'OSM%'");
         rs.next();
-        assertTrue(rs.getInt(1) == 11);
+        assertTrue(rs.getInt(1) == 10);
         rs.close();
         // Check number
         rs = st.executeQuery("SELECT count(ID_NODE) FROM OSM_NODE");
@@ -160,11 +160,11 @@ public class OSMImportTest {
     
     @Test
     public void importOSMFile() throws SQLException {
-        st.execute("DROP TABLE IF EXISTS OSM_TAG, OSM_NODE, OSM_NODE_TAG, OSM_WAY,OSM_WAY_TAG, OSM_WAY_NODE, OSM_RELATION, OSM_RELATION_TAG, OSM_NODE_MEMBER, OSM_WAY_MEMBER, OSM_RELATION_MEMBER;");
+        st.execute("DROP TABLE IF EXISTS  OSM_NODE, OSM_NODE_TAG, OSM_WAY,OSM_WAY_TAG, OSM_WAY_NODE, OSM_RELATION, OSM_RELATION_TAG, OSM_NODE_MEMBER, OSM_WAY_MEMBER, OSM_RELATION_MEMBER;");
         st.execute("CALL OSMRead(" + StringUtils.quoteStringSQL(OSMImportTest.class.getResource("saint_jean.osm").getPath()) + ", 'OSM');");
         ResultSet rs = st.executeQuery("SELECT count(TABLE_NAME) FROM INFORMATION_SCHEMA.TABLES where TABLE_NAME LIKE 'OSM%'");
         rs.next();
-        assertTrue(rs.getInt(1) == 11);
+        assertTrue(rs.getInt(1) == 10);
         rs.close();
         // Check number
         rs = st.executeQuery("SELECT count(ID_NODE) FROM OSM_NODE");
@@ -202,17 +202,27 @@ public class OSMImportTest {
         assertTrue(rs.next());
         assertEquals(3, rs.getInt(1));
         rs.close();
+        
+        rs = st.executeQuery("SELECT TAG_VALUE FROM OSM_NODE_TAG WHERE ID_NODE=1983979521 and TAG_KEY='amenity'");
+        assertTrue(rs.next());
+        assertEquals("post_office", rs.getString(1));
+        rs.close();
+        
+        rs = st.executeQuery("SELECT TAG_VALUE FROM OSM_WAY_TAG WHERE ID_WAY=296514939 and TAG_KEY='building'");
+        assertTrue(rs.next());
+        assertEquals("yes", rs.getString(1));
+        rs.close();
     }
     
     @Test
     public void importOSMFileTwice() throws SQLException {
-        st.execute("DROP TABLE IF EXISTS OSM_TAG, OSM_NODE, OSM_NODE_TAG, OSM_WAY,OSM_WAY_TAG, OSM_WAY_NODE, OSM_RELATION, OSM_RELATION_TAG, OSM_NODE_MEMBER, OSM_WAY_MEMBER, OSM_RELATION_MEMBER;");
+        st.execute("DROP TABLE IF EXISTS  OSM_NODE, OSM_NODE_TAG, OSM_WAY,OSM_WAY_TAG, OSM_WAY_NODE, OSM_RELATION, OSM_RELATION_TAG, OSM_NODE_MEMBER, OSM_WAY_MEMBER, OSM_RELATION_MEMBER;");
         st.execute("CALL OSMRead(" + StringUtils.quoteStringSQL(OSMImportTest.class.getResource("saint_jean.osm").getPath()) + ", 'OSM');");
         st.execute("CALL OSMRead(" + StringUtils.quoteStringSQL(OSMImportTest.class.getResource("saint_jean.osm").getPath()) + ", 'OSM', true);");
 
         ResultSet rs = st.executeQuery("SELECT count(TABLE_NAME) FROM INFORMATION_SCHEMA.TABLES where TABLE_NAME LIKE 'OSM%'");
         rs.next();
-        assertTrue(rs.getInt(1) == 11);
+        assertTrue(rs.getInt(1) == 10);
         rs.close();
         // Check number
         rs = st.executeQuery("SELECT count(ID_NODE) FROM OSM_NODE");


### PR DESCRIPTION
The table tag has been removed to follow the OSM XML model.
Now, a tag (key, value tupple) is stored in the  column names TAG_KEY, TAG_VALUE.
Namely the tables NODE_TAG, WAY_TAG and RELATION_TAG
see #923