### PR TITLE
Improve SQL writer driver function

### DIFF
--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/kml/KMLDriverFunction.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/kml/KMLDriverFunction.java
@@ -65,14 +65,15 @@ public class KMLDriverFunction implements DriverFunction {
     @Override
     public void exportTable(Connection connection, String tableReference, File fileName, ProgressVisitor progress)
             throws SQLException, IOException {
-        KMLWriterDriver kMLWriter = new KMLWriterDriver(connection, tableReference, fileName);
-        kMLWriter.write(progress);
+        KMLWriterDriver kMLWriter = new KMLWriterDriver(connection);
+        kMLWriter.write(progress,tableReference, fileName,null);
     }
 
     @Override
     public void exportTable(Connection connection, String tableReference, File fileName, ProgressVisitor progress,
-                            String options) throws SQLException, IOException {
-        exportTable(connection, tableReference, fileName, progress);
+            String encoding) throws SQLException, IOException {
+        KMLWriterDriver kMLWriter = new KMLWriterDriver(connection);
+        kMLWriter.write(progress, tableReference, fileName, encoding);
     }
 
     @Override

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/kml/KMLWriterDriver.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/kml/KMLWriterDriver.java
@@ -202,12 +202,12 @@ public class KMLWriterDriver {
         try {
             final XMLOutputFactory streamWriterFactory = XMLOutputFactory.newFactory();
             streamWriterFactory.setProperty("escapeCharacters", false);
-            if (encoding == null || encoding.isEmpty()) {
-                encoding = "UTF-8";
+           if (newEncoding == null || newEncoding.isEmpty()) {
+                newEncoding = "UTF-8";
             }
             XMLStreamWriter xmlOut = streamWriterFactory.createXMLStreamWriter(
-                    new BufferedOutputStream(outputStream), encoding);
-            xmlOut.writeStartDocument("UTF-8", "1.0");
+                    new BufferedOutputStream(outputStream), newEncoding);
+            xmlOut.writeStartDocument(newEncoding, "1.0");
             xmlOut.writeStartElement("kml");
             xmlOut.writeDefaultNamespace("http://www.opengis.net/kml/2.2");
             xmlOut.writeNamespace("atom", "http://www.w3.org/2005/Atom");

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/kml/KMLWriterDriver.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/kml/KMLWriterDriver.java
@@ -202,7 +202,8 @@ public class KMLWriterDriver {
         try {
             final XMLOutputFactory streamWriterFactory = XMLOutputFactory.newFactory();
             streamWriterFactory.setProperty("escapeCharacters", false);
-           if (newEncoding == null || newEncoding.isEmpty()) {
+            String newEncoding = encoding;
+            if (newEncoding == null || newEncoding.isEmpty()) {
                 newEncoding = "UTF-8";
             }
             XMLStreamWriter xmlOut = streamWriterFactory.createXMLStreamWriter(

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/properties/ST_Explode.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/properties/ST_Explode.java
@@ -47,7 +47,7 @@ public class ST_Explode extends AbstractFunction implements ScalarFunction {
 
     public ST_Explode() {
         addProperty(PROP_REMARKS, "Explode Geometry Collection into multiple geometries.\n"
-                + "Note : This function supports select query as the first arfument.");
+                + "Note : This function supports select query as the first argument.");
         addProperty(PROP_NOBUFFER, true);
     }
 

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/geojson/GeojsonImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/geojson/GeojsonImportExportTest.java
@@ -866,7 +866,7 @@ public class GeojsonImportExportTest {
     }
     
     
-     @Test
+    @Test
     public void testSelectWriteReadGeojsonLinestring() throws Exception {
         try (Statement stat = connection.createStatement()) {
             stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS");
@@ -886,7 +886,7 @@ public class GeojsonImportExportTest {
     @Test
     public void testSelectWriteRead() throws Exception {
         try (Statement stat = connection.createStatement()) {
-            stat.execute("CALL GeoJsonWrite('target/lines.geojson', '(SELECT st_geomfromtext(''LINESTRING(1 10, 20 15)'', 4326) as the_geom)');");
+            stat.execute("CALL GeoJsonWrite('target/lines.geojson', '(SELECT ST_GEOMFROMTEXT(''LINESTRING(1 10, 20 15)'', 4326) as the_geom)');");
             stat.execute("CALL GeoJsonRead('target/lines.geojson', 'TABLE_LINESTRINGS_READ');");
             ResultSet res = stat.executeQuery("SELECT * FROM TABLE_LINESTRINGS_READ;");
             res.next();

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/geojson/GeojsonImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/geojson/GeojsonImportExportTest.java
@@ -864,5 +864,36 @@ public class GeojsonImportExportTest {
             gjw.write(new EmptyProgressVisitor(), "lineal", new File("target/lineal_export.geojson"),"CP52");
         });
     }
+    
+    
+     @Test
+    public void testSelectWriteReadGeojsonLinestring() throws Exception {
+        try (Statement stat = connection.createStatement()) {
+            stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS");
+            stat.execute("create table TABLE_LINESTRINGS(the_geom GEOMETRY(LINESTRING), id int)");
+            stat.execute("insert into TABLE_LINESTRINGS values( 'LINESTRING(1 2, 5 3, 10 19)', 1)");
+            stat.execute("insert into TABLE_LINESTRINGS values( 'LINESTRING(1 10, 20 15)', 2)");
+            stat.execute("CALL GeoJsonWrite('target/lines.geojson', '(SELECT * FROM TABLE_LINESTRINGS WHERE ID=2)');");
+            stat.execute("CALL GeoJsonRead('target/lines.geojson', 'TABLE_LINESTRINGS_READ');");
+            ResultSet res = stat.executeQuery("SELECT * FROM TABLE_LINESTRINGS_READ;");
+            res.next();
+            assertTrue(((Geometry) res.getObject(1)).equals(WKTREADER.read("LINESTRING(1 10, 20 15)")));
+            res.close();
+            stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS_READ");
+        }
+    }
+    
+    @Test
+    public void testSelectWriteRead() throws Exception {
+        try (Statement stat = connection.createStatement()) {
+            stat.execute("CALL GeoJsonWrite('target/lines.geojson', '(SELECT st_geomfromtext(''LINESTRING(1 10, 20 15)'', 4326) as the_geom)');");
+            stat.execute("CALL GeoJsonRead('target/lines.geojson', 'TABLE_LINESTRINGS_READ');");
+            ResultSet res = stat.executeQuery("SELECT * FROM TABLE_LINESTRINGS_READ;");
+            res.next();
+            assertTrue(((Geometry) res.getObject(1)).equals(WKTREADER.read("LINESTRING(1 10, 20 15)")));
+            res.close();
+            stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS_READ");
+        }
+    }
 
 }

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/geojson/GeojsonImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/geojson/GeojsonImportExportTest.java
@@ -869,7 +869,7 @@ public class GeojsonImportExportTest {
     @Test
     public void testSelectWriteReadGeojsonLinestring() throws Exception {
         try (Statement stat = connection.createStatement()) {
-            stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS");
+            stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS, TABLE_LINESTRINGS_READ");
             stat.execute("create table TABLE_LINESTRINGS(the_geom GEOMETRY(LINESTRING), id int)");
             stat.execute("insert into TABLE_LINESTRINGS values( 'LINESTRING(1 2, 5 3, 10 19)', 1)");
             stat.execute("insert into TABLE_LINESTRINGS values( 'LINESTRING(1 10, 20 15)', 2)");

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/json/JsonImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/json/JsonImportExportTest.java
@@ -36,6 +36,8 @@ import java.sql.Statement;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.locationtech.jts.geom.Geometry;
 
 /**
  *
@@ -107,6 +109,28 @@ public class JsonImportExportTest {
                 stat.execute("CALL JSONWrite('target/result.json', '(SELECT * FROM TABLE_POINT WHERE idarea=1)', 'CP52');");
             }
         });
+    }
+    
+    @Test
+    public void testSelectWriteReadGeojsonLinestring() throws Exception {
+        try (Statement stat = connection.createStatement()) {
+            stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS");
+            stat.execute("create table TABLE_LINESTRINGS(the_geom GEOMETRY(LINESTRING), id int)");
+            stat.execute("insert into TABLE_LINESTRINGS values( 'LINESTRING(1 2, 5 3, 10 19)', 1)");
+            stat.execute("insert into TABLE_LINESTRINGS values( 'LINESTRING(1 10, 20 15)', 2)");
+            stat.execute("CALL JsonWrite('target/lines.json', '(SELECT * FROM TABLE_LINESTRINGS WHERE ID=2)');");
+            String result = new String( Files.readAllBytes(Paths.get("target/lines.json")));
+            assertEquals("{\"THE_GEOM\":\"LINESTRING (1 10, 20 15)\",\"ID\":2}",result);
+        }
+    }
+    
+    @Test
+    public void testSelectWriteRead() throws Exception {
+        try (Statement stat = connection.createStatement()) {
+            stat.execute("CALL JsonWrite('target/lines.json', '(SELECT ST_GEOMFROMTEXT(''LINESTRING(1 10, 20 15)'', 4326) as the_geom)');");
+            String result = new String( Files.readAllBytes(Paths.get("target/lines.json")));
+            assertEquals("{\"THE_GEOM\":\"SRID=4326;LINESTRING (1 10, 20 15)\"}",result);
+        }
     }
     
 }

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/json/JsonImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/json/JsonImportExportTest.java
@@ -112,7 +112,7 @@ public class JsonImportExportTest {
     }
     
     @Test
-    public void testSelectWriteReadGeojsonLinestring() throws Exception {
+    public void testSelectWriteReadJsonLinestring() throws Exception {
         try (Statement stat = connection.createStatement()) {
             stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS");
             stat.execute("create table TABLE_LINESTRINGS(the_geom GEOMETRY(LINESTRING), id int)");
@@ -125,7 +125,7 @@ public class JsonImportExportTest {
     }
     
     @Test
-    public void testSelectWriteRead() throws Exception {
+    public void testSelectWrite() throws Exception {
         try (Statement stat = connection.createStatement()) {
             stat.execute("CALL JsonWrite('target/lines.json', '(SELECT ST_GEOMFROMTEXT(''LINESTRING(1 10, 20 15)'', 4326) as the_geom)');");
             String result = new String( Files.readAllBytes(Paths.get("target/lines.json")));

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/shp/SHPImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/shp/SHPImportExportTest.java
@@ -722,7 +722,7 @@ public class SHPImportExportTest {
     @Test
     public void testSelectWriteReadSHPLinestring() throws Exception {
         try (Statement stat = connection.createStatement()) {
-            stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS");
+            stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS,TABLE_LINESTRINGS_READ");
             stat.execute("create table TABLE_LINESTRINGS(the_geom GEOMETRY(LINESTRING), id int)");
             stat.execute("insert into TABLE_LINESTRINGS values( 'LINESTRING(1 2, 5 3, 10 19)', 1)");
             stat.execute("insert into TABLE_LINESTRINGS values( 'LINESTRING(1 10, 20 15)', 2)");
@@ -730,7 +730,7 @@ public class SHPImportExportTest {
             stat.execute("CALL SHPRead('target/lines.shp', 'TABLE_LINESTRINGS_READ');");
             ResultSet res = stat.executeQuery("SELECT * FROM TABLE_LINESTRINGS_READ;");
             res.next();            
-            GeometryAsserts.assertGeometryEquals("MULTILINESTRING ((1 10, 20 15))",res.getObject("THE_GEOM"));
+            GeometryAsserts.assertGeometryEquals("SRID=4326;MULTILINESTRING ((1 10, 20 15))",res.getObject("THE_GEOM"));
             assertEquals(2, res.getInt("ID"));
             res.close();
             stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS_READ");

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/shp/SHPImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/shp/SHPImportExportTest.java
@@ -44,6 +44,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import org.h2gis.unitTest.GeometryAsserts;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -715,6 +716,38 @@ public class SHPImportExportTest {
         assertTrue(rs.next());
         assertEquals("Zone arborée", rs.getString("cover"));
         rs.close();
+    }
+    
+    
+    @Test
+    public void testSelectWriteReadSHPLinestring() throws Exception {
+        try (Statement stat = connection.createStatement()) {
+            stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS");
+            stat.execute("create table TABLE_LINESTRINGS(the_geom GEOMETRY(LINESTRING), id int)");
+            stat.execute("insert into TABLE_LINESTRINGS values( 'LINESTRING(1 2, 5 3, 10 19)', 1)");
+            stat.execute("insert into TABLE_LINESTRINGS values( 'LINESTRING(1 10, 20 15)', 2)");
+            stat.execute("CALL SHPWrite('target/lines.shp', '(SELECT * FROM TABLE_LINESTRINGS WHERE ID=2)');");
+            stat.execute("CALL SHPRead('target/lines.shp', 'TABLE_LINESTRINGS_READ');");
+            ResultSet res = stat.executeQuery("SELECT * FROM TABLE_LINESTRINGS_READ;");
+            res.next();            
+            GeometryAsserts.assertGeometryEquals("MULTILINESTRING ((1 10, 20 15))",res.getObject("THE_GEOM"));
+            assertEquals(2, res.getInt("ID"));
+            res.close();
+            stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS_READ");
+        }
+    }
+    
+    @Test
+    public void testSelectWriteRead() throws Exception {
+        try (Statement stat = connection.createStatement()) {
+            stat.execute("CALL SHPWrite('target/lines.shp', '(SELECT ST_GEOMFROMTEXT(''LINESTRING(1 10, 20 15)'', 4326) as the_geom)');");
+            stat.execute("CALL SHPRead('target/lines.shp', 'TABLE_LINESTRINGS_READ');");
+            ResultSet res = stat.executeQuery("SELECT * FROM TABLE_LINESTRINGS_READ;");
+            res.next();
+            GeometryAsserts.assertGeometryEquals("SRID=4326;MULTILINESTRING ((1 10, 20 15))",res.getObject("THE_GEOM"));
+            res.close();
+            stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS_READ");
+        }
     }
     
 }

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/tsv/TSVDriverTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/tsv/TSVDriverTest.java
@@ -177,7 +177,7 @@ public class TSVDriverTest {
      @Test
     public void testSelectWriteReadTSVLinestring() throws Exception {
         try (Statement stat = connection.createStatement()) {
-             stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS");
+             stat.execute("DROP TABLE IF EXISTS TABLE_LINESTRINGS, TABLE_LINESTRINGS_READ");
             stat.execute("create table TABLE_LINESTRINGS(the_geom GEOMETRY(LINESTRING), id int)");
             stat.execute("insert into TABLE_LINESTRINGS values( 'LINESTRING(1 2, 5 3, 10 19)', 1)");
             stat.execute("insert into TABLE_LINESTRINGS values( 'LINESTRING(1 10, 20 15)', 2)");


### PR DESCRIPTION
Ensure that all SQL IO writer functions are able to run a select.
Note : The query  must be surrounded by parentheses.

Examples

```SQL
CALL SHPWRITE('/tmp:myfile.shp', '(SELECT ST_BUFFER(the_geom, 12) as the_geom from geoTable where id > 12)');
CALL GEOJSONWRITE('/tmp:myfile.geojson', '(SELECT ST_BUFFER(the_geom, 12) as the_geom from geoTable where id > 12)');
CALL JSONWRITE('/tmp:myfile.json', '(SELECT ST_BUFFER(the_geom, 12) as the_geom from geoTable where id > 12)');
CALL TSVWRITE('/tmp:myfile.tsv', '(SELECT ST_BUFFER(the_geom, 12) as the_geom from geoTable where id > 12)');
```