### PR TITLE
Add utilities for indexes.

### DIFF
--- a/h2gis-utilities/src/main/java/org/h2gis/utilities/JDBCUtilities.java
+++ b/h2gis-utilities/src/main/java/org/h2gis/utilities/JDBCUtilities.java
@@ -27,7 +27,6 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import javax.sql.DataSource;
 import org.h2gis.utilities.wrapper.ConnectionWrapper;
 import org.h2gis.utilities.wrapper.DataSourceWrapper;

--- a/h2gis-utilities/src/main/java/org/h2gis/utilities/JDBCUtilities.java
+++ b/h2gis-utilities/src/main/java/org/h2gis/utilities/JDBCUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * H2GIS is a library that brings spatial support to the H2 Database Engine
  * <http://www.h2database.com>. H2GIS is developed by CNRS
  * <http://www.cnrs.fr/>.
@@ -27,6 +27,7 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import javax.sql.DataSource;
 import org.h2gis.utilities.wrapper.ConnectionWrapper;
 import org.h2gis.utilities.wrapper.DataSourceWrapper;
@@ -38,6 +39,7 @@ import org.h2gis.utilities.wrapper.DataSourceWrapper;
  * @author Nicolas Fortin
  * @author Erwan Bocher
  * @author Adam Gouge
+ * @author Sylvain PALOMINOS (UBS chaire GEOTERA 2020)
  */
 public class JDBCUtilities {
 
@@ -865,6 +867,293 @@ public class JDBCUtilities {
             builder.append(")");
         }
         return builder.toString();
-    } 
-  
+    }
+
+    /**
+     * Returns true if the given column name from the given table is indexed, return false otherwise.
+     *
+     * @param connection {@link Connection} containing the table to check.
+     * @param tableName  Name of the table to check.
+     * @param columnName Name of the column to check.
+     * @return True if the given column is indexed, false otherwise.
+     * @throws SQLException Exception thrown on SQL execution error.
+     */
+    static boolean isIndexed(Connection connection, String tableName, String columnName) throws SQLException {
+        return isIndexed(connection, TableLocation.parse(tableName, isH2DataBase(connection)), columnName);
+    }
+
+    /**
+     * Returns true if the given column name from the given table is indexed, return false otherwise.
+     *
+     * @param connection {@link Connection} containing the table to check.
+     * @param table      {@link TableLocation} of the table to check.
+     * @param columnName Name of the column to check.
+     * @return True if the given column is indexed, false otherwise.
+     * @throws SQLException Exception thrown on SQL execution error.
+     */
+    static boolean isIndexed(Connection connection, TableLocation table, String columnName) throws SQLException {
+        if (connection == null || columnName == null || table == null) {
+            throw new SQLException("Unable to find an index");
+        }
+        boolean isH2 = isH2DataBase(connection);
+        if (isH2) {
+            PreparedStatement ps = connection.prepareStatement("SELECT INDEX_TYPE_NAME FROM INFORMATION_SCHEMA.INDEXES " +
+                    "WHERE INFORMATION_SCHEMA.INDEXES.TABLE_NAME=? " +
+                    "AND INFORMATION_SCHEMA.INDEXES.TABLE_SCHEMA=? " +
+                    "AND INFORMATION_SCHEMA.INDEXES.COLUMN_NAME=?;");
+            ps.setObject(1, table.getTable());
+            ps.setObject(2, table.getSchema("PUBLIC"));
+            ps.setObject(3, TableLocation.capsIdentifier(columnName, isH2));
+            ResultSet rs = ps.executeQuery();
+            return rs.next();
+        } else {
+            String query =  "SELECT  cls.relname, am.amname " +
+                    "FROM  pg_class cls " +
+                    "JOIN pg_am am ON am.oid=cls.relam where cls.oid " +
+                    " in(select attrelid as pg_class_oid from pg_catalog.pg_attribute " +
+                    " where attname = ? and attrelid in " +
+                    "(select b.oid from pg_catalog.pg_indexes a, pg_catalog.pg_class b  where a.schemaname =? and a.tablename =? " +
+                    "and a.indexname = b.relname)) and am.amname in('btree', 'hash', 'gin', 'brin', 'gist', 'spgist') ;";
+            PreparedStatement ps = connection.prepareStatement(query);
+            ps.setObject(1, columnName);
+            ps.setObject(2, table.getSchema("public"));
+            ps.setObject(3, table.getTable());
+            ResultSet rs = ps.executeQuery();
+            return rs.next();
+        }
+    }
+
+    /**
+     * Returns true if the given column name from the given table is indexed, return false otherwise.
+     *
+     * @param connection {@link Connection} containing the table to check.
+     * @param tableName  Name of the table to check.
+     * @param columnName Name of the column to check.
+     * @return True if the given column is indexed, false otherwise.
+     * @throws SQLException Exception thrown on SQL execution error.
+     */
+    static boolean isSpatialIndexed(Connection connection, String tableName, String columnName) throws SQLException {
+        return isSpatialIndexed(connection, TableLocation.parse(tableName, isH2DataBase(connection)), columnName);
+    }
+
+    /**
+     * Returns true if the given column name from the given table is indexed, return false otherwise.
+     *
+     * @param connection {@link Connection} containing the table to check.
+     * @param table      {@link TableLocation} of the table to check.
+     * @param columnName Name of the column to check.
+     * @return True if the given column is indexed, false otherwise.
+     * @throws SQLException Exception thrown on SQL execution error.
+     */
+    static boolean isSpatialIndexed(Connection connection, TableLocation table, String columnName) throws SQLException {
+        if (connection == null || columnName == null || table == null) {
+            throw new SQLException("Unable to find an index");
+        }
+        boolean isH2 = isH2DataBase(connection);
+        if (isH2) {
+            PreparedStatement ps = connection.prepareStatement("SELECT INDEX_TYPE_NAME FROM INFORMATION_SCHEMA.INDEXES " +
+                    "WHERE INFORMATION_SCHEMA.INDEXES.TABLE_NAME=? " +
+                    "AND INFORMATION_SCHEMA.INDEXES.TABLE_SCHEMA=? " +
+                    "AND INFORMATION_SCHEMA.INDEXES.COLUMN_NAME=?;");
+            ps.setObject(1, table.getTable());
+            ps.setObject(2, table.getSchema("PUBLIC"));
+            ps.setObject(3, TableLocation.capsIdentifier(columnName, isH2));
+            ResultSet rs = ps.executeQuery();
+            while(rs.next()) {
+                if(rs.getString("INDEX_TYPE_NAME").contains("SPATIAL")){
+                    return true;
+                }
+            }
+            return false;
+        } else {
+            String query =  "SELECT  cls.relname, am.amname " +
+                    "FROM  pg_class cls " +
+                    "JOIN pg_am am ON am.oid=cls.relam where cls.oid " +
+                    " in(select attrelid as pg_class_oid from pg_catalog.pg_attribute " +
+                    " where attname = ? and attrelid in " +
+                    "(select b.oid from pg_catalog.pg_indexes a, pg_catalog.pg_class b  where a.schemaname =? and a.tablename =? " +
+                    "and a.indexname = b.relname)) and am.amname = 'gist' ;";
+            PreparedStatement ps = connection.prepareStatement(query);
+            ps.setObject(1, columnName);
+            ps.setObject(2, table.getSchema("public"));
+            ps.setObject(3, table.getTable());
+            ResultSet rs = ps.executeQuery();
+            return rs.next();
+        }
+    }
+
+    /**
+     * Create an index on the given column of the given table on the given connection.
+     * @param connection Connection to access to the desired table.
+     * @param table      Table containing the column to index.
+     * @param columnName Name of the column to index.
+     * @return True if the column have been indexed, false otherwise.
+     * @throws SQLException Exception thrown on SQL execution error.
+     */
+    public static boolean createIndex(Connection connection, TableLocation table, String columnName) throws SQLException {
+        if(connection == null || table == null || columnName == null){
+            throw new SQLException("Unable to create an index");
+        }
+        boolean isH2 = isH2DataBase(connection);
+        connection.createStatement().execute("CREATE INDEX IF NOT EXISTS " + table.toString(isH2) + "_" + columnName +
+                " ON " + table.toString(isH2) + " USING BTREE (" + TableLocation.capsIdentifier(columnName, isH2) + ")");
+        return true;
+    }
+
+    /**
+     * Create an index on the given column of the given table on the given connection.
+     * @param connection Connection to access to the desired table.
+     * @param table      Name of the table containing the column to index.
+     * @param columnName Name of the column to index.
+     * @return True if the column have been indexed, false otherwise.
+     * @throws SQLException Exception thrown on SQL execution error.
+     */
+    public static boolean createIndex(Connection connection, String table, String columnName) throws SQLException {
+        return createIndex(connection, TableLocation.parse(table, isH2DataBase(connection)), columnName);
+    }
+
+    /**
+     * Create a spatial index on the given column of the given table on the given connection.
+     * @param connection Connection to access to the desired table.
+     * @param table      Table containing the column to index.
+     * @param columnName Name of the column to index.
+     * @return True if the column have been indexed, false otherwise.
+     * @throws SQLException Exception thrown on SQL execution error.
+     */
+    public static boolean createSpatialIndex(Connection connection, TableLocation table, String columnName) throws SQLException {
+        if(connection == null || table == null || columnName == null){
+            throw new SQLException("Unable to create a spatial index");
+        }
+        boolean isH2 = isH2DataBase(connection);
+        if (isH2) {
+            connection.createStatement().execute("CREATE INDEX IF NOT EXISTS " + table.toString(isH2) + "_" + columnName +
+                    " ON " + table.toString(isH2) + " USING RTREE (" + TableLocation.capsIdentifier(columnName, isH2)  + ")");
+        } else {
+            connection.createStatement().execute("CREATE INDEX IF NOT EXISTS "+  table.toString(isH2) + "_" + columnName +
+                    " ON "  + table.toString(isH2)  + " USING GIST (" + TableLocation.capsIdentifier(columnName, isH2)  + ")");
+        }
+        return true;
+    }
+
+    /**
+     * Create a spatial index on the given column of the given table on the given connection.
+     * @param connection Connection to access to the desired table.
+     * @param table      Name of the table containing the column to index.
+     * @param columnName Name of the column to index.
+     * @return True if the column have been indexed, false otherwise.
+     * @throws SQLException Exception thrown on SQL execution error.
+     */
+    public static boolean createSpatialIndex(Connection connection, String table, String columnName) throws SQLException {
+        return createSpatialIndex(connection, TableLocation.parse(table, isH2DataBase(connection)), columnName);
+    }
+
+    /**
+     * Drop the index of the given column of the given table on yhe given connection.
+     * @param connection Connection to access to the desired table.
+     * @param table      Table containing the column to drop index.
+     * @param columnName Name of the column to drop index.
+     * @throws SQLException Exception thrown on SQL execution error.
+     */
+    public static void dropIndex(Connection connection, TableLocation table, String columnName) throws SQLException {
+        if(connection == null || table == null || columnName == null){
+            throw new SQLException("Unable to drop index");
+        }
+        List<String> indexes = new ArrayList<>();
+        boolean isH2 = isH2DataBase(connection);
+        if (isH2) {
+            PreparedStatement ps = connection.prepareStatement("SELECT INDEX_NAME FROM INFORMATION_SCHEMA.INDEXES " +
+                            "WHERE INFORMATION_SCHEMA.INDEXES.TABLE_NAME=? " +
+                            "AND INFORMATION_SCHEMA.INDEXES.TABLE_SCHEMA=? " +
+                            "AND INFORMATION_SCHEMA.INDEXES.COLUMN_NAME=?;");
+            ps.setObject(1, table.getTable());
+            ps.setObject(2, table.getSchema("PUBLIC"));
+            ps.setObject(3, TableLocation.capsIdentifier(columnName, isH2));
+            ResultSet rs = ps.executeQuery();
+            while(rs.next()) {
+                indexes.add(rs.getString("INDEX_NAME"));
+            }
+        }else {
+            PreparedStatement ps = connection.prepareStatement("SELECT  cls.relname as index_name " +
+                    "FROM  pg_class cls " +
+                    "JOIN pg_am am ON am.oid=cls.relam where cls.oid " +
+                    " in(select attrelid as pg_class_oid from pg_catalog.pg_attribute " +
+                    " where attname = ? and attrelid in " +
+                    "(select b.oid from pg_catalog.pg_indexes a, pg_catalog.pg_class b  where a.schemaname =? and a.tablename =? " +
+                    "and a.indexname = b.relname)) and am.amname in('btree', 'hash', 'gin', 'brin', 'gist', 'spgist') ;");
+            ps.setObject(1, columnName);
+            ps.setObject(2, table.getSchema("public"));
+            ps.setObject(3, table.getTable());
+            ResultSet rs = ps.executeQuery();
+            while(rs.next()) {
+                indexes.add(rs.getString("index_name"));
+            }
+        }
+        for (String index : indexes) {
+            connection.createStatement().execute("DROP INDEX IF EXISTS " + index);
+        }
+    }
+
+    /**
+     * Drop the index of the given column of the given table on yhe given connection.
+     * @param connection Connection to access to the desired table.
+     * @param table      Name of the table containing the column to drop index.
+     * @param columnName Name of the column to drop index.
+     * @throws SQLException Exception thrown on SQL execution error.
+     */
+    public static void dropIndex(Connection connection, String table, String columnName) throws SQLException {
+        dropIndex(connection, TableLocation.parse(table, isH2DataBase(connection)), columnName);
+    }
+
+
+    /**
+     * Drop the all the indexes of the given table on yhe given connection.
+     * @param connection Connection to access to the desired table.
+     * @param table      Table containing the column to drop index.
+     * @throws SQLException Exception thrown on SQL execution error.
+     */
+    public static void dropIndex(Connection connection, TableLocation table) throws SQLException {
+        if(connection == null || table == null){
+            throw new SQLException("Unable to drop index");
+        }
+        List<String> indexes = new ArrayList<>();
+        boolean isH2 = isH2DataBase(connection);
+        if (isH2) {
+            PreparedStatement ps = connection.prepareStatement("SELECT INDEX_NAME FROM INFORMATION_SCHEMA.INDEXES " +
+                    "WHERE INFORMATION_SCHEMA.INDEXES.TABLE_NAME=? " +
+                    "AND INFORMATION_SCHEMA.INDEXES.TABLE_SCHEMA=?;");
+            ps.setObject(1, table.getTable());
+            ps.setObject(2, table.getSchema("PUBLIC"));
+            ResultSet rs = ps.executeQuery();
+            while(rs.next()) {
+                indexes.add(rs.getString("INDEX_NAME"));
+            }
+        }else {
+            PreparedStatement ps = connection.prepareStatement("SELECT  cls.relname as index_name " +
+                    "FROM  pg_class cls " +
+                    "JOIN pg_am am ON am.oid=cls.relam where cls.oid " +
+                    " in(select attrelid as pg_class_oid from pg_catalog.pg_attribute " +
+                    " where attrelid in " +
+                    "(select b.oid from pg_catalog.pg_indexes a, pg_catalog.pg_class b  where a.schemaname =? and a.tablename =? " +
+                    "and a.indexname = b.relname)) and am.amname in('btree', 'hash', 'gin', 'brin', 'gist', 'spgist') ;");
+            ps.setObject(1, table.getSchema("public"));
+            ps.setObject(2, table.getTable());
+            ResultSet rs = ps.executeQuery();
+            while(rs.next()) {
+                indexes.add(rs.getString("index_name"));
+            }
+        }
+        for (String index : indexes) {
+            connection.createStatement().execute("DROP INDEX IF EXISTS " + index);
+        }
+    }
+
+    /**
+     * Drop the all the indexes of the given table on yhe given connection.
+     * @param connection Connection to access to the desired table.
+     * @param table      Name of the table containing the column to drop index.
+     * @throws SQLException Exception thrown on SQL execution error.
+     */
+    public static void dropIndex(Connection connection, String table) throws SQLException {
+        dropIndex(connection, TableLocation.parse(table, isH2DataBase(connection)));
+    }
 }

--- a/h2gis-utilities/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
+++ b/h2gis-utilities/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,0 +1,9 @@
+moduleName=H2GIS Groovy extension
+moduleVersion=1.0
+extensionClasses=org.h2gis.utilities.JDBCUtilities, \
+  org.h2gis.utilities.GeographyUtilities, \
+  org.h2gis.utilities.GeometryTableUtilities, \
+  org.h2gis.utilities.TableUtilities, \
+  org.h2gis.utilities.URIUtilities, \
+  org.h2gis.utilities.FileUtilities
+staticExtensionClasses=

--- a/h2gis-utilities/src/test/java/org/h2gis/utilities/JDBCUtilitiesTest.java
+++ b/h2gis-utilities/src/test/java/org/h2gis/utilities/JDBCUtilitiesTest.java
@@ -313,6 +313,119 @@ public class JDBCUtilitiesTest {
         assertTrue(JDBCUtilities.wrapConnection(new CustomConnection(connection)) instanceof ConnectionWrapper);
     }
 
+    @Test
+    public void isIndexedTest() throws SQLException {
+        st.execute("DROP TABLE IF EXISTS TEST_INDEX");
+        st.execute("CREATE TABLE TEST_INDEX(no_idx GEOMETRY, idx GEOMETRY, spatial_idx GEOMETRY)");
+        st.execute("CREATE INDEX ON TEST_INDEX(idx)");
+        st.execute("CREATE INDEX ON TEST_INDEX USING RTREE(spatial_idx)");
+
+        String tableName = "test_index";
+        TableLocation table = TableLocation.parse(tableName, JDBCUtilities.isH2DataBase(connection));
+        assertFalse(JDBCUtilities.isIndexed(connection, tableName, "no_idx"));
+        assertFalse(JDBCUtilities.isIndexed(connection, table, "no_idx"));
+        assertTrue(JDBCUtilities.isIndexed(connection, tableName, "idx"));
+        assertTrue(JDBCUtilities.isIndexed(connection, table, "idx"));
+        assertTrue(JDBCUtilities.isIndexed(connection, tableName, "spatial_idx"));
+        assertTrue(JDBCUtilities.isIndexed(connection, table, "spatial_idx"));
+    }
+
+    @Test
+    public void isSpatialIndexedTest() throws SQLException {
+        st.execute("DROP TABLE IF EXISTS TEST_INDEX");
+        st.execute("CREATE TABLE TEST_INDEX(no_idx GEOMETRY, idx GEOMETRY, spatial_idx GEOMETRY)");
+        st.execute("CREATE INDEX ON TEST_INDEX(idx)");
+        st.execute("CREATE INDEX ON TEST_INDEX USING RTREE(spatial_idx)");
+
+        String tableName = "test_index";
+        TableLocation table = TableLocation.parse(tableName, JDBCUtilities.isH2DataBase(connection));
+
+        assertFalse(JDBCUtilities.isSpatialIndexed(connection, tableName, "no_idx"));
+        assertFalse(JDBCUtilities.isSpatialIndexed(connection, table, "no_idx"));
+        assertFalse(JDBCUtilities.isSpatialIndexed(connection, tableName, "idx"));
+        assertFalse(JDBCUtilities.isSpatialIndexed(connection, table, "idx"));
+        assertTrue(JDBCUtilities.isSpatialIndexed(connection, tableName, "spatial_idx"));
+        assertTrue(JDBCUtilities.isSpatialIndexed(connection, table, "spatial_idx"));
+    }
+
+    @Test
+    public void createIndexTest() throws SQLException {
+        st.execute("DROP TABLE IF EXISTS TEST_INDEX");
+        st.execute("CREATE TABLE TEST_INDEX(no_idx GEOMETRY, idx GEOMETRY, spatial_idx GEOMETRY)");
+
+        String tableName = "test_index";
+        TableLocation table = TableLocation.parse(tableName, JDBCUtilities.isH2DataBase(connection));
+
+        assertTrue(JDBCUtilities.createIndex(connection, table, "idx"));
+        assertTrue(JDBCUtilities.isIndexed(connection, table, "idx"));
+        assertFalse(JDBCUtilities.isSpatialIndexed(connection, table, "idx"));
+        assertTrue(JDBCUtilities.createIndex(connection, tableName, "spatial_idx"));
+        assertTrue(JDBCUtilities.isIndexed(connection, tableName, "spatial_idx"));
+        assertFalse(JDBCUtilities.isSpatialIndexed(connection, tableName, "spatial_idx"));
+    }
+
+    @Test
+    public void createSpatialIndexTest() throws SQLException {
+        st.execute("DROP TABLE IF EXISTS TEST_INDEX");
+        st.execute("CREATE TABLE TEST_INDEX(no_idx GEOMETRY, idx GEOMETRY, spatial_idx GEOMETRY)");
+
+        String tableName = "test_index";
+        TableLocation table = TableLocation.parse(tableName, JDBCUtilities.isH2DataBase(connection));
+
+        assertTrue(JDBCUtilities.createSpatialIndex(connection, table, "idx"));
+        assertTrue(JDBCUtilities.isSpatialIndexed(connection, table, "idx"));
+        assertTrue(JDBCUtilities.isIndexed(connection, table, "idx"));
+        assertTrue(JDBCUtilities.createSpatialIndex(connection, tableName, "spatial_idx"));
+        assertTrue(JDBCUtilities.isSpatialIndexed(connection, tableName, "spatial_idx"));
+        assertTrue(JDBCUtilities.isIndexed(connection, tableName, "spatial_idx"));
+    }
+
+    @Test
+    public void isDropIndexesTest() throws SQLException {
+        st.execute("DROP TABLE IF EXISTS TEST_INDEX");
+        st.execute("CREATE TABLE TEST_INDEX(no_idx GEOMETRY, idx GEOMETRY, spatial_idx GEOMETRY)");
+        st.execute("CREATE INDEX ON TEST_INDEX(idx)");
+        st.execute("CREATE INDEX ON TEST_INDEX USING RTREE(spatial_idx)");
+
+        String tableName = "test_index";
+        TableLocation table = TableLocation.parse(tableName, JDBCUtilities.isH2DataBase(connection));
+
+        assertTrue(JDBCUtilities.isIndexed(connection, table, "idx"));
+        assertTrue(JDBCUtilities.isIndexed(connection, table, "spatial_idx"));
+
+        JDBCUtilities.dropIndex(connection, tableName);
+
+        assertFalse(JDBCUtilities.isIndexed(connection, table, "idx"));
+        assertFalse(JDBCUtilities.isIndexed(connection, table, "spatial_idx"));
+
+
+
+        st.execute("CREATE INDEX ON TEST_INDEX(idx)");
+        st.execute("CREATE INDEX ON TEST_INDEX USING RTREE(spatial_idx)");
+
+        assertTrue(JDBCUtilities.isIndexed(connection, table, "idx"));
+        assertTrue(JDBCUtilities.isIndexed(connection, table, "spatial_idx"));
+
+        JDBCUtilities.dropIndex(connection, table);
+
+        assertFalse(JDBCUtilities.isIndexed(connection, table, "idx"));
+        assertFalse(JDBCUtilities.isIndexed(connection, table, "spatial_idx"));
+
+
+
+        st.execute("CREATE INDEX ON TEST_INDEX(idx)");
+        st.execute("CREATE INDEX ON TEST_INDEX USING RTREE(spatial_idx)");
+
+        assertTrue(JDBCUtilities.isIndexed(connection, table, "idx"));
+        assertTrue(JDBCUtilities.isIndexed(connection, table, "spatial_idx"));
+
+        JDBCUtilities.dropIndex(connection, table, "idx");
+        assertFalse(JDBCUtilities.isIndexed(connection, table, "idx"));
+
+        JDBCUtilities.dropIndex(connection, table, "spatial_idx");
+        assertFalse(JDBCUtilities.isIndexed(connection, table, "spatial_idx"));
+    }
+
     private class CustomDataSource implements DataSource {
 
         @Override


### PR DESCRIPTION
Adds to the `JDBCUtilities` class different index related methods : 
 - createIndex/createSpatialIndex
 - dropIndex
 - isIndexed, isSpatialIndexed

Each methods signature is doubled : one for the table name as `String`, an other for the table name as `TableLocation`. 