### PR TITLE
PrecisionReducer is less tolerant since 1.18.0

### DIFF
--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/generalize/ST_PrecisionReducer.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/generalize/ST_PrecisionReducer.java
@@ -52,7 +52,7 @@ public class ST_PrecisionReducer extends DeterministicScalarFunction {
      * @throws SQLException
      */
     public static Geometry precisionReducer(Geometry geometry, int nbDec) throws SQLException {
-        if(geometry == null){
+        if (geometry == null) {
             return null;
         }
         if (nbDec < 0) {
@@ -60,7 +60,11 @@ public class ST_PrecisionReducer extends DeterministicScalarFunction {
         }
         PrecisionModel pm = new PrecisionModel(scaleFactorForDecimalPlaces(nbDec));
         GeometryPrecisionReducer geometryPrecisionReducer = new GeometryPrecisionReducer(pm);
-        return geometryPrecisionReducer.reduce(geometry);
+        try {
+            return geometryPrecisionReducer.reduce(geometry);
+        } catch (IllegalArgumentException ex) {
+            return geometry;
+        }
     }
 
     /**


### PR DESCRIPTION
 so if we have a topology exception then return the input geometry