### PR TITLE
Update H2GIS to support H2 2.0.204

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,3 +6,6 @@
 + Upgrade to JTS 1.18.2
 + Add new function ST_VariableBuffer
 + Add new function ST_SubDivide
++ Update H2 from 2.0.202 to 2.0.204
++ Added a workaround due to the new column type name returned for geometry data type
+eg GEOMETRY(POINT) instead of only GEOMETRY

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/dbf/DBFDriverFunction.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/dbf/DBFDriverFunction.java
@@ -403,8 +403,7 @@ public class DBFDriverFunction implements DriverFunction {
         int columnCount = metaData.getColumnCount();
         for(int fieldId= 1; fieldId <= columnCount; fieldId++) {
             final String fieldTypeName = metaData.getColumnTypeName(fieldId);
-            // TODO postgis check field type
-            if(!fieldTypeName.equalsIgnoreCase("geometry")) {
+            if(!fieldTypeName.toLowerCase().startsWith("geometry")) {
                 DBFType dbfType = getDBFType(metaData.getColumnType(fieldId), fieldTypeName, metaData.getColumnDisplaySize(fieldId), metaData.getPrecision(fieldId));
                 try {
                     dbaseFileHeader.addColumn(metaData.getColumnName(fieldId),dbfType.type, dbfType.fieldLength, dbfType.decimalCount);

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonWriteDriver.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonWriteDriver.java
@@ -521,7 +521,7 @@ public class GeoJsonWriteDriver {
         for (int i = 1; i <= columnCount; i++) {
             final String fieldTypeName = resultSetMetaData.getColumnTypeName(i);
             String columnName = resultSetMetaData.getColumnName(i);
-            if (!fieldTypeName.equalsIgnoreCase("geometry")
+            if (!fieldTypeName.toLowerCase().startsWith("geometry")
                     && isSupportedPropertyType(columnName, resultSetMetaData.getColumnType(i), fieldTypeName)) {
                 cachedColumnIndex.put(columnName, i);
                 columnCountProperties++;

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/kml/KMLWriterDriver.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/kml/KMLWriterDriver.java
@@ -295,7 +295,7 @@ public class KMLWriterDriver {
             kmlFields = new HashMap<Integer, String>();
             for (int fieldId = 1; fieldId <= columnCount; fieldId++) {
                 final String fieldTypeName = metaData.getColumnTypeName(fieldId);
-                if (!fieldTypeName.equalsIgnoreCase("geometry")) {
+                if (!fieldTypeName.toLowerCase().startsWith("geometry")) {
                     String fieldName = metaData.getColumnName(fieldId);
                     writeSimpleField(xmlOut, fieldName, getKMLType(metaData.getColumnType(fieldId), fieldTypeName));
                     kmlFields.put(fieldId, fieldName);

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/utility/IOMethods.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/utility/IOMethods.java
@@ -439,7 +439,7 @@ public class IOMethods {
                     for (int i = 0; i < columnsCount; i++) {
                         int index = i + 1;
                         Object value = inputRes.getObject(index);
-                        if (inputMetadata.getColumnTypeName(index).equalsIgnoreCase("GEOMETRY")) {
+                        if (inputMetadata.getColumnTypeName(index).toLowerCase().startsWith("geometry")) {
                             geomColumnAndSRID.put(inputMetadata.getColumnName(index), ((Geometry) value).getSRID());
                         }
                         preparedStatement.setObject(index, value);

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/properties/ST_Explode.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/properties/ST_Explode.java
@@ -280,17 +280,23 @@ public class ST_Explode extends AbstractFunction implements ScalarFunction {
                 ResultSetMetaData metadata = rsQuery.getMetaData();
                 columnCount = metadata.getColumnCount();
                 for (int i = 1; i <= columnCount; i++) {
+
                     String type = metadata.getColumnTypeName(i);
-                    if (type.toLowerCase().startsWith("geometry")&& spatialFieldIndex==-1) {
-                        spatialFieldIndex = i;
-                    }
                     String columnName =metadata.getColumnName(i);
                     String label = metadata.getColumnLabel(i);
                     if(label!=null){
                         columnName = label;
                     }
-                    rs.addColumn(columnName, metadata.getColumnType(i),
-                            type, metadata.getPrecision(i), metadata.getScale(i));
+                    //TODO : workarround due to the geometry type signature returned by H2  eg. GEOMETRY(POLYGON)
+                    if (type.toLowerCase().startsWith("geometry")&& spatialFieldIndex==-1) {
+                        spatialFieldIndex = i;
+                        rs.addColumn(columnName, metadata.getColumnType(i),
+                                "GEOMETRY", metadata.getPrecision(i), metadata.getScale(i));
+                    }
+                    else{
+                        rs.addColumn(columnName, metadata.getColumnType(i),
+                                type, metadata.getPrecision(i), metadata.getScale(i));
+                    }
                 }
 
             } catch (SQLException ex) {

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/properties/ST_Explode.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/properties/ST_Explode.java
@@ -281,7 +281,7 @@ public class ST_Explode extends AbstractFunction implements ScalarFunction {
                 columnCount = metadata.getColumnCount();
                 for (int i = 1; i <= columnCount; i++) {
                     String type = metadata.getColumnTypeName(i);
-                    if (type.equalsIgnoreCase("geometry")&& spatialFieldIndex==-1) {
+                    if (type.toLowerCase().startsWith("geometry")&& spatialFieldIndex==-1) {
                         spatialFieldIndex = i;
                     }
                     String columnName =metadata.getColumnName(i);

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/geojson/GeojsonImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/geojson/GeojsonImportExportTest.java
@@ -634,7 +634,7 @@ public class GeojsonImportExportTest {
             ResultSet res = stat.executeQuery("SELECT * FROM TABLE_COMPLEX_READ;");
             ResultSetMetaData metadata = res.getMetaData();
             assertEquals(16, metadata.getColumnCount());
-            assertEquals("GEOMETRY", metadata.getColumnTypeName(1));
+            assertEquals("GEOMETRY(POINT Z, 0)", metadata.getColumnTypeName(1));
             assertEquals("DOUBLE PRECISION", metadata.getColumnTypeName(2));
             assertEquals("DOUBLE PRECISION", metadata.getColumnTypeName(3));
             assertEquals("BIGINT", metadata.getColumnTypeName(4));

--- a/h2gis-functions/src/test/java/org/h2gis/functions/spatial/SpatialFunctionTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/spatial/SpatialFunctionTest.java
@@ -99,7 +99,7 @@ public class SpatialFunctionTest {
 
     @Test
     public void test_ST_ExplodeEmptyGeometryCollection() throws Exception {
-        st.execute("create table test(the_geom GEOMETRY, val Integer);"
+        st.execute("DROP TABLE TEST IF EXISTS;  create table test(the_geom GEOMETRY, val Integer);"
                 + "insert into test VALUES (ST_GeomFromText('MULTILINESTRING EMPTY'),108),"
                 + " (ST_GeomFromText('MULTIPOINT EMPTY'),109),"
                 + " (ST_GeomFromText('MULTIPOLYGON EMPTY'),110),"
@@ -123,7 +123,7 @@ public class SpatialFunctionTest {
 
     @Test
     public void test_ST_ExplodeWithQuery1() throws Exception {
-        st.execute("CREATE TABLE forests ( fid INTEGER NOT NULL PRIMARY KEY, name CHARACTER VARYING(64),"
+        st.execute("DROP TABLE forests IF EXISTS;  CREATE TABLE forests ( fid INTEGER NOT NULL PRIMARY KEY, name CHARACTER VARYING(64),"
                 + " boundary GEOMETRY(MULTIPOLYGON));"
                 + "INSERT INTO forests VALUES(109, 'Green Forest', ST_MPolyFromText( 'MULTIPOLYGON(((28 26,28 0,84 0,"
                 + "84 42,28 26), (52 18,66 23,73 9,48 6,52 18)),((59 18,67 18,67 13,59 13,59 18)))', 101));");
@@ -135,7 +135,7 @@ public class SpatialFunctionTest {
 
     @Test
     public void test_ST_ExplodeWithQuery3() throws Exception {
-        st.execute("CREATE TABLE forests ( fid INTEGER NOT NULL PRIMARY KEY, name CHARACTER VARYING(64),"
+        st.execute("DROP TABLE forests IF EXISTS; CREATE TABLE forests ( fid INTEGER NOT NULL PRIMARY KEY, name CHARACTER VARYING(64),"
                 + " boundary GEOMETRY(MULTIPOLYGON));"
                 + "INSERT INTO forests VALUES(109, 'Green Forest', ST_MPolyFromText( 'MULTIPOLYGON(((28 26,28 0,84 0,"
                 + "84 42,28 26), (52 18,66 23,73 9,48 6,52 18)),((59 18,67 18,67 13,59 13,59 18)))', 101));");
@@ -147,7 +147,7 @@ public class SpatialFunctionTest {
 
     @Test
     public void test_ST_ExplodeWithQuery4() throws Exception {
-        st.execute("CREATE TABLE forests ( fid INTEGER NOT NULL PRIMARY KEY, name CHARACTER VARYING(64),"
+        st.execute("DROP TABLE forests IF EXISTS;  CREATE TABLE forests ( fid INTEGER NOT NULL PRIMARY KEY, name CHARACTER VARYING(64),"
                 + " boundary GEOMETRY(MULTIPOLYGON), \"LIMIT\" INTEGER);"
                 + "INSERT INTO forests VALUES(109, 'Green Forest', ST_MPolyFromText( 'MULTIPOLYGON(((28 26,28 0,84 0,"
                 + "84 42,28 26), (52 18,66 23,73 9,48 6,52 18)),((59 18,67 18,67 13,59 13,59 18)))', 101), 666);");
@@ -159,7 +159,7 @@ public class SpatialFunctionTest {
 
     @Test
     public void test_ST_ExplodeWithQuery2() throws Exception {
-        st.execute("CREATE TABLE forests ( fid INTEGER NOT NULL PRIMARY KEY, name CHARACTER VARYING(64),"
+        st.execute("DROP TABLE forests IF EXISTS;  CREATE TABLE forests ( fid INTEGER NOT NULL PRIMARY KEY, name CHARACTER VARYING(64),"
                 + " boundary GEOMETRY(MULTIPOLYGON));"
                 + "INSERT INTO forests VALUES(109, 'Green Forest', ST_MPolyFromText( 'MULTIPOLYGON(((28 26,28 0,84 0,"
                 + "84 42,28 26), (52 18,66 23,73 9,48 6,52 18)),((59 18,67 18,67 13,59 13,59 18)))', 101));");

--- a/h2gis-utilities/src/main/java/org/h2gis/utilities/GeometryTableUtilities.java
+++ b/h2gis-utilities/src/main/java/org/h2gis/utilities/GeometryTableUtilities.java
@@ -19,16 +19,17 @@
  */
 package org.h2gis.utilities;
 
-import java.sql.*;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-
 import org.h2gis.utilities.dbtypes.DBTypes;
 import org.h2gis.utilities.dbtypes.DBUtils;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
 import static org.h2gis.utilities.dbtypes.DBTypes.*;
 import static org.h2gis.utilities.dbtypes.DBUtils.getDBType;
 
@@ -108,8 +109,9 @@ public class GeometryTableUtilities {
         ResultSetMetaData metadata = resultSet.getMetaData();
         int columnCount = metadata.getColumnCount();
         for (int i = 1; i <= columnCount; i++) {
-            if (metadata.getColumnTypeName(i).equalsIgnoreCase("geometry")) {
-                return new Tuple<>(metadata.getColumnName(i), new GeometryMetaData());
+            GeometryMetaData geomMeta = GeometryMetaData.getMetaDataFromTablePattern(metadata.getColumnTypeName(i));
+            if (geomMeta != null) {
+                return new Tuple<>(metadata.getColumnName(i), geomMeta);
             }
         }
         throw new SQLException("The query does not contain a geometry field");
@@ -128,8 +130,9 @@ public class GeometryTableUtilities {
         ResultSetMetaData metadata = resultSet.getMetaData();
         int columnCount = metadata.getColumnCount();
         for (int i = 1; i <= columnCount; i++) {
-            if (metadata.getColumnTypeName(i).equalsIgnoreCase("geometry")) {
-                geometryMetaDatas.put(metadata.getColumnName(i), new GeometryMetaData());
+            GeometryMetaData geomMeta = GeometryMetaData.getMetaDataFromTablePattern(metadata.getColumnTypeName(i));
+            if (geomMeta != null) {
+                geometryMetaDatas.put(metadata.getColumnName(i), geomMeta);
             }
         }
         return geometryMetaDatas;
@@ -605,7 +608,7 @@ public class GeometryTableUtilities {
         ResultSetMetaData meta = resultSet.getMetaData();
         int columnCount = meta.getColumnCount();
         for (int i = 1; i <= columnCount; i++) {
-            if (meta.getColumnTypeName(i).equalsIgnoreCase("geometry")) {
+            if (meta.getColumnTypeName(i).toLowerCase().startsWith("geometry")) {
                 return new Tuple<>(meta.getColumnName(i), i);
             }
         }
@@ -625,7 +628,7 @@ public class GeometryTableUtilities {
         ResultSetMetaData meta = resultSet.getMetaData();
         int columnCount = meta.getColumnCount();
         for (int i = 1; i <= columnCount; i++) {
-            if (meta.getColumnTypeName(i).equalsIgnoreCase("geometry")) {
+            if (meta.getColumnTypeName(i).toLowerCase().startsWith("geometry")) {
                 return true;
             }
         }
@@ -665,7 +668,7 @@ public class GeometryTableUtilities {
                 ResultSetMetaData meta = resultSet.getMetaData();
                 int columnCount = meta.getColumnCount();
                 for (int i = 1; i <= columnCount; i++) {
-                    if (meta.getColumnTypeName(i).equalsIgnoreCase("geometry")) {
+                    if (meta.getColumnTypeName(i).toLowerCase().startsWith("geometry")) {
                         return true;
                     }
                 }
@@ -962,7 +965,7 @@ public class GeometryTableUtilities {
         LinkedHashMap<String, Integer> namesWithIndexes = new LinkedHashMap<>();
         int columnCount = metadata.getColumnCount();
         for (int i = 1; i <= columnCount; i++) {
-            if (metadata.getColumnTypeName(i).equalsIgnoreCase("geometry")) {
+            if (metadata.getColumnTypeName(i).toLowerCase().startsWith("geometry")) {
                 namesWithIndexes.put(metadata.getColumnName(i), i);
             }
         }
@@ -1016,7 +1019,7 @@ public class GeometryTableUtilities {
         ArrayList<String> namesWithIndexes = new ArrayList<>();
         int columnCount = metadata.getColumnCount();
         for (int i = 1; i <= columnCount; i++) {
-            if (metadata.getColumnTypeName(i).equalsIgnoreCase("geometry")) {
+            if (metadata.getColumnTypeName(i).toLowerCase().startsWith("geometry")) {
                 namesWithIndexes.add(metadata.getColumnName(i));
             }
         }
@@ -1068,9 +1071,9 @@ public class GeometryTableUtilities {
     public static Tuple<String, Integer> getFirstGeometryColumnNameAndIndex(ResultSetMetaData metadata) throws SQLException {
         int columnCount = metadata.getColumnCount();
         for (int i = 1; i <= columnCount; i++) {
-            if (metadata.getColumnTypeName(i).equalsIgnoreCase("geometry")) {
-                return new Tuple<>(metadata.getColumnName(i), i);
-            }
+                if (metadata.getColumnTypeName(i).toLowerCase().startsWith("geometry")) {
+                    return new Tuple<>(metadata.getColumnName(i), i);
+                }
         }
         throw new SQLException("The query doesn't contain any geometry field");
     }

--- a/h2gis-utilities/src/main/java/org/h2gis/utilities/JDBCUtilities.java
+++ b/h2gis-utilities/src/main/java/org/h2gis/utilities/JDBCUtilities.java
@@ -882,7 +882,7 @@ public class JDBCUtilities {
                                 builder.append("(").append(metadata.getColumnDisplaySize(i)).append(")");
                             } else if (columnType == Types.DOUBLE) {
                                 builder.append(columnName).append(" ").append("DOUBLE PRECISION");
-                            } else if (columnTypeName.equalsIgnoreCase("geometry")) {
+                            } else if (columnTypeName.toLowerCase().startsWith("geometry")) {
                                 if (geomMetadatas.isEmpty()) {
                                     builder.append(columnName).append(" ").append(columnTypeName);
                                 } else {
@@ -890,7 +890,7 @@ public class JDBCUtilities {
                                     if (geomMetadata.getGeometryTypeCode() == GeometryTypeCodes.GEOMETRY && geomMetadata.getSRID() == 0) {
                                         builder.append(columnName).append(" ").append(columnTypeName);
                                     } else {
-                                        builder.append(columnName).append(" ").append(columnTypeName)
+                                        builder.append(columnName).append(" ").append("GEOMETRY")
                                                 .append("(").append(geomMetadata.getGeometryType()).append(",").append(geomMetadata.getSRID()).append(")");
                                     }
                                 }
@@ -991,7 +991,7 @@ public class JDBCUtilities {
                     builder.append("(").append(metadata.getColumnDisplaySize(i)).append(")");
                 } else if (columnType == Types.DOUBLE) {
                     builder.append(columnName).append(" ").append("DOUBLE PRECISION");
-                } else if (columnTypeName.equalsIgnoreCase("geometry")) {
+                } else if (columnTypeName.toLowerCase().startsWith("geometry")) {
                     builder.append(columnName).append(" ").append(columnTypeName);
                 }
                 else if (columnTypeName.equalsIgnoreCase("decfloat")) {

--- a/h2gis-utilities/src/main/java/org/h2gis/utilities/TableUtilities.java
+++ b/h2gis-utilities/src/main/java/org/h2gis/utilities/TableUtilities.java
@@ -60,9 +60,21 @@ public class TableUtilities {
                 ResultSetMetaData metadata = resultSet.getMetaData();
                 int columnCount = metadata.getColumnCount();
                 for (int columnId = 1; columnId <= columnCount; columnId++) {
-                    rs.addColumn(metadata.getColumnName(columnId), metadata.getColumnType(columnId),
-                    metadata.getColumnTypeName(columnId), metadata.getPrecision(columnId)
-                    , metadata.getScale(columnId));
+                    String type = metadata.getColumnTypeName(columnId);
+                    String columnName =metadata.getColumnName(columnId);
+                    String label = metadata.getColumnLabel(columnId);
+                    if(label!=null){
+                        columnName = label;
+                    }
+                    //TODO : workarround due to the geometry type signature returned by H2  eg. GEOMETRY(POLYGON)
+                    if (type.toLowerCase().startsWith("geometry")) {
+                        rs.addColumn(columnName, metadata.getColumnType(columnId),
+                                "GEOMETRY", metadata.getPrecision(columnId), metadata.getScale(columnId));
+                    }
+                    else{
+                        rs.addColumn(columnName, metadata.getColumnType(columnId),
+                                type, metadata.getPrecision(columnId), metadata.getScale(columnId));
+                    }
                 }
             } finally {
                 resultSet.close();

--- a/h2gis-utilities/src/main/java/org/h2gis/utilities/wrapper/SpatialResultSetMetaDataImpl.java
+++ b/h2gis-utilities/src/main/java/org/h2gis/utilities/wrapper/SpatialResultSetMetaDataImpl.java
@@ -46,7 +46,7 @@ public class SpatialResultSetMetaDataImpl extends ResultSetMetaDataWrapper imple
         if(firstGeometryFieldIndex==-1) {
             int columnCount =getColumnCount();
             for(int idColumn=1;idColumn<=columnCount;idColumn++) {
-                if(getColumnTypeName(idColumn).equalsIgnoreCase("geometry")) {
+                if(getColumnTypeName(idColumn).toLowerCase().startsWith("geometry")) {
                     firstGeometryFieldIndex = idColumn;
                     break;
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.orbisgis</groupId>
         <artifactId>orbisparent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>h2gis-parent</artifactId>
     <version>2.0.0-SNAPSHOT</version>


### PR DESCRIPTION
Related to https://github.com/orbisgis/h2gis/issues/1236

Note that there are some issues with the ST_EXPLODE function that uses the SimpleResult.
It seems that H2 doesn't recognize a geometry column build with the following properties : 

```java
rs.addColumn(columnName, metadata.getColumnType(i),
                            type, metadata.getPrecision(i), metadata.getScale(i));

```
where 
columnName =  the_geom
metadata.getColumnType(i) = 1111
type = GEOMETRY(MULTIPOLYGON)
metadata.getPrecision(i)= 1048576
metadata.getScale(i) = 0

Link to the code : https://github.com/ebocher/H2GIS/blob/H2_204/h2gis-functions/src/main/java/org/h2gis/functions/spatial/properties/ST_Explode.java#L292

We must investigate.

@katzyn 

