### PR TITLE
Remove space in CI snapshot workflow name.

### DIFF
--- a/.github/workflows/CI_snapshot.yml
+++ b/.github/workflows/CI_snapshot.yml
@@ -1,4 +1,4 @@
-name: CI snapshot
+name: CI_snapshot
 
 on:
   push:


### PR DESCRIPTION
Remove space in CI snapshot workflow name.