### PR TITLE
Fix ST_DistanceSphere

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,3 +12,4 @@
 + Fix estimated extend on schema (#1286)
 + `TableLocation.parse` now restore a `TableLocation.toString()` to the initial state
 + Make test run again without PostGIS instance
++ ST_DistanceSphere throws an exception when the twon input srids are different (#1292)

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/properties/ST_DistanceSphere.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/properties/ST_DistanceSphere.java
@@ -58,8 +58,11 @@ public class ST_DistanceSphere extends DeterministicScalarFunction {
      * @return minimum distance in meters between two geometries
      */
     public static Double distanceSphere(Connection connection, Geometry a,Geometry b) throws SQLException {
-        if(a==null || b==null || (a.getSRID()!=b.getSRID())) {
+        if(a==null || b==null) {
             return null;
+        }
+        if(a.getSRID()!=b.getSRID()){
+            throw new SQLException("Operation on mixed SRID geometries not supported");
         }
 
         if (crsf == null) {


### PR DESCRIPTION
ST_DistanceSphere throws an exception when two input geometries do not have the same srid