### PR TITLE
Fix ST_ACCUM and ST_Union with empty geom

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,3 +18,4 @@
 + Move all OSGI dependencies to h2gis-functions-osgi and to postgis-jts-osgi
 + Move classes used for datasource creation (`H2GISOsgiDBFactory` and `DataSourceFactoryImpl`) to `*-osgi` package and keep test purpose class (`HGISSimpleDBFactory`) in `h2gis-functions`
 + Fix `ST_OrderingEquals` and `ST_AsBinary` parameters to handle the case of a null geometry
++ Fix ST_Accum and ST_Union to filter empty geometry

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/aggregate/ST_Accum.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/aggregate/ST_Accum.java
@@ -82,8 +82,10 @@ public class ST_Accum extends AbstractFunction implements Aggregate {
                 List<Geometry> toUnitTmp = new ArrayList<Geometry>(size);
                 for (int i = 0; i < size; i++) {
                     Geometry geomsub = geom.getGeometryN(i);
-                    toUnitTmp.add(geomsub);
-                    feedDim(geomsub);
+                    if(!geomsub.isEmpty()) {
+                        toUnitTmp.add(geomsub);
+                        feedDim(geomsub);
+                    }
                 }
                 toUnite.addAll(toUnitTmp);
             } else {
@@ -97,14 +99,15 @@ public class ST_Accum extends AbstractFunction implements Aggregate {
     public void add(Object o) throws SQLException {
         if (o instanceof Geometry) {
             Geometry geom = (Geometry) o;
-            if(srid ==-1){                
-                srid=geom.getSRID();
-            }
-            if(srid==geom.getSRID()){
-            addGeometry(geom);
-            }
-            else {
-              throw new SQLException("Operation on mixed SRID geometries not supported");  
+            if(!geom.isEmpty()) {
+                if (srid == -1) {
+                    srid = geom.getSRID();
+                }
+                if (srid == geom.getSRID()) {
+                    addGeometry(geom);
+                } else {
+                    throw new SQLException("Operation on mixed SRID geometries not supported");
+                }
             }
         } else if (o != null) {
             throw new SQLException("ST_Accum accepts only Geometry values. Input: " +

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/operators/ST_Union.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/operators/ST_Union.java
@@ -54,6 +54,12 @@ public class ST_Union extends DeterministicScalarFunction {
         if(a==null || b==null) {
             return null;
         }
+        if(a.isEmpty()){
+            return a;
+        }
+        if(b.isEmpty()){
+            return UnaryUnionOp.union(a);
+        }
         if(a.getSRID()!=b.getSRID()){
             throw new SQLException("Operation on mixed SRID geometries not supported");
         }

--- a/h2gis-functions/src/test/java/org/h2gis/functions/spatial/SpatialFunctionTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/spatial/SpatialFunctionTest.java
@@ -2584,6 +2584,31 @@ public class SpatialFunctionTest {
     }
 
     @Test
+    public void test_ST_UnionSRID4() throws Exception {
+        ResultSet rs = st.executeQuery("SELECT ST_Union('SRID=4326;POLYGON ((230 350, 460 350, 460 200, 230 200, 230 350))'::geometry,'LINESTRING EMPTY'::GEOMETRY) the_geom");
+        rs.next();
+        assertGeometryEquals("SRID=4326;POLYGON ((230 200, 230 350, 460 350, 460 200, 230 200))", rs.getObject(1));
+        rs.close();
+    }
+
+    @Test
+    public void test_ST_UnionSRID5() throws Exception {
+        ResultSet rs = st.executeQuery("SELECT ST_Union('MULTIPOINT ((1 0), EMPTY, EMPTY, (2 2))'::GEOMETRY) the_geom");
+        rs.next();
+        assertGeometryEquals("MULTIPOINT ((1 0), (2 2))", rs.getObject(1));
+        rs.close();
+    }
+
+    @Test
+    public void test_ST_UnionSRID6() throws Exception {
+        ResultSet rs = st.executeQuery("SELECT ST_Union(st_accum(the_geom)::GEOMETRY) the_geom from" +
+                "(select 'SRID=4326; POINT(0 0)'::GEOMETRY as the_geom union select 'POINT EMPTY'::GEOMETRY as the_geom) as foo ");
+        rs.next();
+        assertGeometryEquals("SRID=4326;POINT (0 0)", rs.getObject(1));
+        rs.close();
+    }
+
+    @Test
     public void test_ST_EstimatedExtent1() throws Exception {
         st.execute("DROP TABLE  forests IF EXISTS;" +
                 "CREATE TABLE forests ( fid INTEGER NOT NULL PRIMARY KEY, name CHARACTER VARYING(64),"


### PR DESCRIPTION
Filter the empty geometry set to the st_accum function to avoid srid problem because an empty geometry doesn't have any srid

Fix ST_Union when the first and the second geometries are empty