### PR TITLE
Rebase ST_Union

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,5 +4,4 @@
 + Change move some log info to debug mode
 + Use the next generation overlay
 + Add grid size precision to snap intersection, difference and symdifference operators
-+ Improve ST_Union to use CoverageUnion when the input geometry contains only polygons
 + Use OverlayNGRobust instead of OverlayNG

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/operators/ST_Union.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/operators/ST_Union.java
@@ -2,18 +2,18 @@
  * H2GIS is a library that brings spatial support to the H2 Database Engine
  * <a href="http://www.h2database.com">http://www.h2database.com</a>. H2GIS is developed by CNRS
  * <a href="http://www.cnrs.fr/">http://www.cnrs.fr/</a>.
- *
- * This code is part of the H2GIS project. H2GIS is free software; 
+ * <p>
+ * This code is part of the H2GIS project. H2GIS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU
  * Lesser General Public License as published by the Free Software Foundation;
  * version 3.0 of the License.
- *
+ * <p>
  * H2GIS is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details <http://www.gnu.org/licenses/>.
- *
- *
+ * <p>
+ * <p>
  * For more information, please consult: <a href="http://www.h2gis.org/">http://www.h2gis.org/</a>
  * or contact directly: info_at_h2gis.org
  */
@@ -21,12 +21,9 @@
 package org.h2gis.functions.spatial.operators;
 
 import java.sql.SQLException;
-import java.util.HashSet;
 
 import org.h2gis.api.DeterministicScalarFunction;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryCollection;
-import org.locationtech.jts.operation.overlayng.CoverageUnion;
 import org.locationtech.jts.operation.overlayng.OverlayNG;
 import org.locationtech.jts.operation.overlayng.OverlayNGRobust;
 
@@ -36,8 +33,6 @@ import org.locationtech.jts.operation.overlayng.OverlayNGRobust;
  * @author Nicolas Fortin
  */
 public class ST_Union extends DeterministicScalarFunction {
-
-    static HashSet dims = new HashSet();
 
     /**
      * Default constructor
@@ -57,29 +52,21 @@ public class ST_Union extends DeterministicScalarFunction {
      * @return union of Geometries a and b
      * @throws java.sql.SQLException
      */
-    public static Geometry union(Geometry a,Geometry b) throws SQLException {
-        if(a==null || b==null) {
+    public static Geometry union(Geometry a, Geometry b) throws SQLException {
+        if (a == null || b == null) {
             return null;
         }
-        if(a.isEmpty()){
+        if (a.isEmpty()) {
             return a;
         }
-        if(b.isEmpty()){
-            findDim(a);
-            if(dims.size()>1) {
-                return OverlayNGRobust.union(a);
-            }else if(dims.contains(2)){
-                return CoverageUnion.union(a);
-            }else{
-                return OverlayNGRobust.union(a);
-            }
+        if (b.isEmpty()) {
+            return OverlayNGRobust.union(a);
         }
-        if(a.getSRID()!=b.getSRID()){
+        if (a.getSRID() != b.getSRID()) {
             throw new SQLException("Operation on mixed SRID geometries not supported");
         }
-        return OverlayNGRobust.overlay(a,b, OverlayNG.UNION);
+        return OverlayNGRobust.overlay(a, b, OverlayNG.UNION);
     }
-
 
 
     /**
@@ -87,35 +74,12 @@ public class ST_Union extends DeterministicScalarFunction {
      * @return union of all Geometries in geomList
      */
     public static Geometry union(Geometry geomList) {
-        if(geomList==null){
+        if (geomList == null) {
             return null;
         }
-        if(geomList.isEmpty()){
+        if (geomList.isEmpty()) {
             return geomList;
         }
-        findDim(geomList);
-        if(dims.size()>1) {
-            return OverlayNGRobust.union(geomList);
-        }else if(dims.contains(2)){
-            return CoverageUnion.union(geomList);
-        }else{
-            return OverlayNGRobust.union(geomList);
-        }
-    }
-
-
-    /**
-     * Utilities to collect the dimmensions of geometry
-     * @param geometry
-     */
-    public static void findDim(Geometry geometry){
-        if (geometry instanceof GeometryCollection) {
-            final int nbOfGeometries = geometry.getNumGeometries();
-            for (int i = 0; i < nbOfGeometries; i++) {
-                findDim(geometry.getGeometryN(i));
-            }
-        } else {
-            dims.add(geometry.getDimension());
-        }
+        return OverlayNGRobust.union(geomList);
     }
 }


### PR DESCRIPTION
Do not use UnionCoverage with ST_Union because the input geometries must be correctly noded.
See the figures.

Input geometry

![input_data_union](https://user-images.githubusercontent.com/1820572/197686984-a5aa6c59-50b5-49e8-b874-309747fcce28.png)

UnionCoverage output

![coverage_union](https://user-images.githubusercontent.com/1820572/197687064-7e5e9b96-0c0a-471f-a495-2ab5846a72db.png)

Robust union overlay output
![input_data_union_ok](https://user-images.githubusercontent.com/1820572/197687127-3034c0dc-a1db-40b3-89f3-45f31d5c5674.png)




