### PR TITLE
Fix failing test on windows and 'h2gis-dist' execution

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,3 +20,4 @@
 + Extend ST_MinimumBoundingRadius to copy all fields when the input data is a table or a select query
 + Add ST_Project function
 + Update H2 to 2.2.224 and SLFJ
++ Change the `h2gis-dist` main class from `org.h2.tools.Server` to `org.h2.tools.Console`

--- a/h2gis-dist/pom.xml
+++ b/h2gis-dist/pom.xml
@@ -83,7 +83,7 @@
                     <arguments>
                         <argument>-classpath</argument>
                         <classpath />
-                        <argument>org.h2.tools.Server</argument>
+                        <argument>org.h2.tools.Console</argument>
                     </arguments>
                 </configuration>
             </plugin>
@@ -94,7 +94,7 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>org.h2.tools.Server</mainClass>
+                            <mainClass>org.h2.tools.Console</mainClass>
                             <addClasspath>true</addClasspath>
                             <classpathPrefix>bin/</classpathPrefix>
                         </manifest>

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/dbf/DBFEngineTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/dbf/DBFEngineTest.java
@@ -202,7 +202,7 @@ public class  DBFEngineTest {
         Statement st = connection.createStatement();
         st.execute("drop table if exists sotchi");
         st.execute("CALL DBFREAD("+StringUtils.quoteStringSQL(DBFEngineTest.class.getResource("sotchi.dbf").getPath())+", 'SOTCHI', 'cp1251');");
-        st.execute("CALL DBFWRITE('target/sotchi.dbf', 'SOTCHI', 'cp1251');");
+        st.execute("CALL DBFWRITE('target/sotchi.dbf', 'SOTCHI', 'cp1251', true);");
         st.execute("drop table if exists sotchi");
         st.execute("CALL FILE_TABLE('target/sotchi.dbf', 'SOTCHI_GOODHEADER');");
         // Check if fields name are OK

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/dbf/DBFImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/dbf/DBFImportExportTest.java
@@ -187,7 +187,7 @@ public class DBFImportExportTest {
     @Test
     public void testWriteDecimal() throws SQLException, IOException {
         Statement stat = connection.createStatement();
-        File dbfFile = new File("target/area_export.dbf");
+        File dbfFile = new File("target/area_export2.dbf");
         stat.execute("DROP TABLE IF EXISTS AREA, AREA2");
         stat.execute("create table area(id integer, val DECIMAL(13,3), descr CHAR(50))");
         double v1 = 40656458.41;


### PR DESCRIPTION
#### Module h2gis
- Fix the test `DBFEngineTest.readDBFRussianWrongEncodingThenWriteThenRead()` which was failing when it is run twice without cleaning the `target/` folder
- Fix the test `DBFImportExportTest.testWriteDecimal()` which was failing under windows because when the whole class is run, the file `target/area_export2.dbf` stay in use and isn't accessible to this test.
#### Module h2gis-dist
- When the `h2gis-dist` jar is run, in the browser, it was not possible to create a new database like in the `h2` jar. The main class in the h2 pom is `org.h2.tools.Console` instead of `org.h2.tools.Server`
