### PR TITLE
GeoJSON with ZM

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,3 +24,4 @@
 + Set scope as test for slf4j-simple
 + Zip and unzip functions with subfolders
 + GeoJson driver must be able to read json extension
++ GeoJson handle the M ordinate. The limitation is only ZM is supported (default Z value to 0 if M is given but not Z)

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonWriteDriver.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonWriteDriver.java
@@ -753,6 +753,9 @@ public class GeoJsonWriteDriver {
         if (!Double.isNaN(coordinate.getZ())) {
             gen.writeNumber(coordinate.getZ());
         }
+        if(!Double.isNaN(coordinate.getM())) {
+            gen.writeNumber(coordinate.getM());
+        }
         gen.writeEndArray();
     }
 

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/ST_AsGeoJSON.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/ST_AsGeoJSON.java
@@ -134,6 +134,9 @@ public class ST_AsGeoJSON extends DeterministicScalarFunction {
         if (!Double.isNaN(coord.z)) {
             sb.append(",").append(CoordinateUtils.round(coord.z, maxdecimaldigits));
         }
+        if (!Double.isNaN(coord.getM())) {
+            sb.append(",").append(CoordinateUtils.round(coord.getM(), maxdecimaldigits));
+        }
         sb.append("]}");
     }
 


### PR DESCRIPTION
M can be useful for time based geometries.

On kepler.gl travel information is encoded into M ordinate on linestrings from geojson files.