### PR TITLE
SnapToGrid function

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## Changelog for v2.2.2
 - Read CPG file attached to the shapefile- 
 - Declare the schema for the spatial_ref_sys table
+- Add SnapToGrid function

--- a/h2gis-functions/src/main/java/org/h2gis/functions/factory/H2GISFunctions.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/factory/H2GISFunctions.java
@@ -62,6 +62,7 @@ import org.h2gis.functions.spatial.edit.*;
 import org.h2gis.functions.spatial.generalize.ST_PrecisionReducer;
 import org.h2gis.functions.spatial.generalize.ST_Simplify;
 import org.h2gis.functions.spatial.generalize.ST_SimplifyPreserveTopology;
+import org.h2gis.functions.spatial.generalize.ST_SnapToGrid;
 import org.h2gis.functions.spatial.linear_referencing.ST_LineInterpolatePoint;
 import org.h2gis.functions.spatial.linear_referencing.ST_LineSubstring;
 import org.h2gis.functions.spatial.mesh.ST_ConstrainedDelaunay;
@@ -336,7 +337,8 @@ public class H2GISFunctions {
                 new ST_MinimumBoundingRadius(),
                 new ST_Project(),
                 new ST_IsProjectedCRS(),
-                new ST_IsGeographicCRS()
+                new ST_IsGeographicCRS(),
+                new ST_SnapToGrid()
         };
     }
 

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/generalize/ST_SnapToGrid.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/generalize/ST_SnapToGrid.java
@@ -28,40 +28,39 @@ import org.locationtech.jts.precision.GeometryPrecisionReducer;
 import java.sql.SQLException;
 
 /**
- *
- * @author Erwan Bocher
+ * Function to snap a geometry according a grid size
+ * @author Erwan Bocher, CNRS, 2024
  */
-public class ST_PrecisionReducer extends DeterministicScalarFunction {
+public class ST_SnapToGrid extends DeterministicScalarFunction {
 
-    public ST_PrecisionReducer() {
-        addProperty(PROP_REMARKS, "Reduce the geometry precision. Decimal_Place is the number of decimals to keep.");
+    public ST_SnapToGrid() {
+        addProperty(PROP_REMARKS, "Snap all points of the input geometry to the grid defined by its origin and cell size.");
     }
 
     @Override
     public String getJavaStaticMethod() {
-        return "precisionReducer";
+        return "execute";
     }
 
     /**
-     * Reduce the geometry precision. Decimal_Place is the number of decimals to
-     * keep.
+     * Reduce the geometry precision. cell_size is resolution of grid to snap the points
      *
      * @param geometry
-     * @param nbDec
+     * @param cell_size
      * @return
      * @throws SQLException
      */
-    public static Geometry precisionReducer(Geometry geometry, int nbDec) throws SQLException {
+    public static Geometry execute(Geometry geometry, float cell_size) throws SQLException {
         if (geometry == null) {
             return null;
         }
-        if(nbDec==0){
+        if(cell_size==0){
             return geometry;
         }
-        if (nbDec < 0) {
-            throw new SQLException("Decimal_places has to be >= 0.");
+        if (cell_size < 0) {
+            throw new SQLException("cell size has to be >= 0.");
         }
-        PrecisionModel pm = new PrecisionModel(scaleFactorForDecimalPlaces(nbDec));
+        PrecisionModel pm = new PrecisionModel(Math.round(1/cell_size));
         GeometryPrecisionReducer geometryPrecisionReducer = new GeometryPrecisionReducer(pm);
         try {
             return geometryPrecisionReducer.reduce(geometry);

--- a/h2gis-functions/src/test/java/org/h2gis/functions/spatial/processing/ProcessingFunctionTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/spatial/processing/ProcessingFunctionTest.java
@@ -318,6 +318,23 @@ public class ProcessingFunctionTest {
     }
 
     @Test
+    public void test_ST_SnapToGrid1() throws Exception {
+        ResultSet rs = st.executeQuery("SELECT ST_SnapToGrid('LINESTRING(1.1115678 2.123, 4.111111 3.2374897, 4.11112 3.23748667)'::GEOMETRY, 0.001);");
+        rs.next();
+        assertGeometryEquals("LINESTRING(1.112 2.123,4.111 3.237)", rs.getBytes(1));
+        rs.close();
+    }
+
+    @Test
+    public void test_ST_SnapToGrid2() throws Exception {
+        ResultSet rs = st.executeQuery("SELECT ST_SnapToGrid('LINESTRINGZ(1.1115678 2.123 1, 4.111111 3.2374897 1, 4.11112 3.23748667 1)'::GEOMETRY, 0.001);");
+        rs.next();
+        assertGeometryEquals("LINESTRINGZ(1.112 2.123 1,4.111 3.237 1)", rs.getBytes(1));
+        rs.close();
+    }
+
+
+    @Test
     public void test_ST_RingSideBuffer1() throws Exception {
         ResultSet rs = st.executeQuery("SELECT ST_RingSideBuffer('SRID=4326;LINESTRING (-10 10, 10 10)'::GEOMETRY, 10, 3);");
         assertTrue(rs.next());


### PR DESCRIPTION
A single SnapToGrid function that reduces the precision of the geometry according a grid size