### PR TITLE
Add ST_SnapToSelf function

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Do not ask for SRID when geometry is empty
 - Add the name of the table in the FGB header
 - Fix null way id on OSM file
+- Add ST_SnapToSelf function

--- a/h2gis-functions/src/main/java/org/h2gis/functions/factory/H2GISFunctions.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/factory/H2GISFunctions.java
@@ -75,6 +75,7 @@ import org.h2gis.functions.spatial.predicates.*;
 import org.h2gis.functions.spatial.properties.*;
 import org.h2gis.functions.spatial.snap.ST_Project;
 import org.h2gis.functions.spatial.snap.ST_Snap;
+import org.h2gis.functions.spatial.snap.ST_SnapToSelf;
 import org.h2gis.functions.spatial.split.ST_LineIntersector;
 import org.h2gis.functions.spatial.split.ST_Split;
 import org.h2gis.functions.spatial.split.ST_SubDivide;
@@ -338,7 +339,8 @@ public class H2GISFunctions {
                 new ST_Project(),
                 new ST_IsProjectedCRS(),
                 new ST_IsGeographicCRS(),
-                new ST_SnapToGrid()
+                new ST_SnapToGrid(),
+                new ST_SnapToSelf()
         };
     }
 

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/snap/ST_SnapToSelf.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/snap/ST_SnapToSelf.java
@@ -1,0 +1,74 @@
+/**
+ * H2GIS is a library that brings spatial support to the H2 Database Engine
+ * <a href="http://www.h2database.com">http://www.h2database.com</a>. H2GIS is developed by CNRS
+ * <a href="http://www.cnrs.fr/">http://www.cnrs.fr/</a>.
+ * <p>
+ * This code is part of the H2GIS project. H2GIS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation;
+ * version 3.0 of the License.
+ * <p>
+ * H2GIS is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details <http://www.gnu.org/licenses/>.
+ * <p>
+ * <p>
+ * For more information, please consult: <a href="http://www.h2gis.org/">http://www.h2gis.org/</a>
+ * or contact directly: info_at_h2gis.org
+ */
+
+package org.h2gis.functions.spatial.snap;
+
+import org.h2gis.api.DeterministicScalarFunction;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.operation.overlay.snap.GeometrySnapper;
+
+import java.sql.SQLException;
+
+/**
+ * Snaps a geometry to itself with a given tolerance
+ * Allows optionally cleaning the result to ensure it is topologically valid
+ *
+ * @author Erwan Bocher
+ */
+public class ST_SnapToSelf extends DeterministicScalarFunction {
+
+    public ST_SnapToSelf() {
+        addProperty(PROP_REMARKS, "Snaps a geometry to itself with a given tolerance.\n" +
+                "Allows optionally cleaning the result to ensure it is topologically valid. true by default");
+    }
+
+    @Override
+    public String getJavaStaticMethod() {
+        return "execute";
+    }
+
+
+    /**
+     * Snaps a geometry to itself with a given tolerance
+     *
+     * @param geometryA a geometry to snap
+     * @param distance the tolerance to use
+     * @return the snapped geometries
+     * @throws SQLException
+     */
+    public static Geometry execute(Geometry geometryA, double distance ) throws SQLException {
+        return execute(geometryA, distance, true);
+    }
+    /**
+     * Snaps a geometry to itself with a given tolerance
+     *
+     * @param geometryA a geometry to snap
+     * @param distance the tolerance to use
+     * @param clean true to clean the geometry
+     * @return the snapped geometries
+     * @throws SQLException
+     */
+    public static Geometry execute(Geometry geometryA, double distance, boolean clean ) throws SQLException {
+        if (geometryA == null ) {
+            return null;
+        }
+        return GeometrySnapper.snapToSelf(geometryA, distance, clean);
+    }
+}

--- a/h2gis-functions/src/test/java/org/h2gis/functions/spatial/processing/ProcessingFunctionTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/spatial/processing/ProcessingFunctionTest.java
@@ -333,6 +333,14 @@ public class ProcessingFunctionTest {
         rs.close();
     }
 
+    @Test
+    public void test_ST_SnapToSelf1() throws Exception {
+        ResultSet rs = st.executeQuery("SELECT ST_SnapToSelf('POLYGON ((0 0, 1 1, 2 1, 3 0.5, 2 -3, 3 0.499, 0 0))'::GEOMETRY, 0.001);");
+        rs.next();
+        assertGeometryEquals("POLYGON ((0 0, 1 1, 2 1, 3 0.5, 3 0.499, 0 0))", rs.getBytes(1));
+        rs.close();
+    }
+
 
     @Test
     public void test_ST_RingSideBuffer1() throws Exception {


### PR DESCRIPTION
A function to snap a geometry to itself

```sql
SELECT ST_SnapToSelf('POLYGON ((0 0, 1 1, 2 1, 3 0.5, 2 -3, 3 0.499, 0 0))'::GEOMETRY, 0.001)
```

Input
![geoms](https://github.com/orbisgis/h2gis/assets/1820572/0dcbe36f-63ae-4633-8053-84675dc41789)

Output
![geoms_pb](https://github.com/orbisgis/h2gis/assets/1820572/ab0509eb-c98e-45cc-9d8b-584102781c48)
