### PR TITLE
Fix duplicate dependency version issue (JTS 1.19 and 1.20)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,3 +6,5 @@
 - Fix bug when read GeometryCollection with the ST_GeomFromGeoJSON function 
 - Fix github actions
 - Fix mixed srid error on empty geometry with ST_Extent #1400
+- Remove transitive dependency from flatgeobuffer to JTS version 1.19 (should use 1.20 of jts-core)
+  

--- a/h2gis-functions/pom.xml
+++ b/h2gis-functions/pom.xml
@@ -59,6 +59,12 @@
         <dependency>
             <groupId>org.wololo</groupId>
             <artifactId>flatgeobuf</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.locationtech.jts</groupId>
+                    <artifactId>jts-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Remove transitive dependency of flatgeobuff that use an old version of jts 

about https://github.com/dbeaver/dbeaver/issues/37093