### PR TITLE
Update version of flat geo buf

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,3 +14,5 @@
 - Fix bug when read GeometryCollection with the ST_GeomFromGeoJSON function 
 - ST_MAKEGRID and ST_MAKEGRIDPOINTS : add an option to order the cells starting from the upper left corner 
 - Change ST_Collect to scalar function
+- Upgrade the version of FlatGeoBuffer driver (update of guava, flatbuffer)
+  

--- a/h2gis-functions/pom.xml
+++ b/h2gis-functions/pom.xml
@@ -59,14 +59,7 @@
         <dependency>
             <groupId>org.wololo</groupId>
             <artifactId>flatgeobuf</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.locationtech.jts</groupId>
-                    <artifactId>jts-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.orbisgis</groupId>
             <artifactId>h2gis-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <osgi-enterprise-version>5.0.0</osgi-enterprise-version>
         <poly2tri-version>0.7.0</poly2tri-version>
         <postgis-jdbc-version>2021.1.0</postgis-jdbc-version>
-        <flatgeobuf-version>3.26.2</flatgeobuf-version>
+        <flatgeobuf-version>[3.27, 4)</flatgeobuf-version>
         <postgresql-version>42.6.0</postgresql-version>
         <jna-version>0.5.0</jna-version>
         <cts-version>1.7.1</cts-version>


### PR DESCRIPTION
Update version of flatgeobuf, use the maven version range in order to upgrade up to (excluded) major version of flat geo buffer driver