### PR TITLE
Fix storage of Byte and Boolean type in FGB Driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ agent-output
 
 graal_isolate.h
 graal_isolate_dynamic.h
+
+.DS_Store

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,3 +30,4 @@
 - Exposes C API using graalvm to allow the lib to communicate with other programs 
 - Fix an error for C API fetch_rows
 - Replace Poly2Tri by Tinfour library, signature of ST_ConstrainedDelaunay now have a minDistancePoint parameter for merging input coordinates
+- Fix storage of Boolean and Byte type of the Flat GeoBuffer storage driver issue #1437

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/fgb/FGBWriteDriver.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/fgb/FGBWriteDriver.java
@@ -120,7 +120,7 @@ public class FGBWriteDriver {
                     if (deleteFiles) {
                         Files.deleteIfExists(fileName.toPath());
                     } else if (fileName.exists()) {
-                        throw new IOException("The json file already exist.");
+                        throw new IOException("The fgb file already exist.");
                     }
                     PreparedStatement ps = connection.prepareStatement(tableName, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
                     JDBCUtilities.attachCancelResultSet(ps, progress);
@@ -246,10 +246,10 @@ public class FGBWriteDriver {
                         byte type = column.type;
                         switch (type) {
                             case ColumnType.Bool:
-                                bufferManager.putShort((byte) ((boolean) value ? 1 : 0));
+                                bufferManager.put((byte) ((boolean) value ? 1 : 0));
                                 break;
                             case ColumnType.Byte:
-                                bufferManager.putShort((byte) value);
+                                bufferManager.put((byte) value);
                                 break;
                             case ColumnType.Short:
                                 bufferManager.putShort(((Integer) value).shortValue());


### PR DESCRIPTION
For unknown reason, byte and boolean were stored using Short type (2 bytes instead of 1)