### PR TITLE
Update build arguments in pom.xml for GraalVM

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,3 +9,5 @@
 - Add ST_ClusterIntersecting function
 - Add ST_ClusterWithin function
 - Improve clustering functions to load only ids
+- Fix CPU compatibility issues in GraalVM about https://github.com/orbisgis/h2gis/issues/1473
+  

--- a/h2gis-graalvm/pom.xml
+++ b/h2gis-graalvm/pom.xml
@@ -159,15 +159,16 @@
                     </agent>
                     <imageName>h2gis</imageName>
                     <buildArgs>
-                        <!-- TODO create a profil for linux <arg>&#45;&#45;gc=G1</arg>-->
-                        <arg>-march=native</arg>
+                        <buildArg>-march=compatibility</buildArg>
+                        <!-- Other standard flags for shared libraries -->
+                        <buildArg>--shared</buildArg>
+                        <buildArg>-H:+AllowFoldMethods</buildArg>
                         <arg>--enable-url-protocols=http,https,tcp</arg>
                         <!-- Enable runtime reporting for missing elements -->
                         <arg>--report-unsupported-elements-at-runtime</arg>
                         <!-- Initialize certain packages/classes at runtime -->
                         <arg>--initialize-at-run-time=org.h2,org.h2gis</arg>
                         <arg>--features=org.h2gis.graalvm.GraalCInterfaceEntryPointFeature</arg>
-                        <arg>--shared</arg>
                         <arg>
                             -H:ResourceConfigurationFiles=${project.basedir}/src/main/resources/META-INF/native-image/resource-config.json
                         </arg>


### PR DESCRIPTION
about issue 1473, compatibility mode

The error CPU_FEATURE_CHECK_FAILED (Error 23) occurs because GraalVM, by default, often optimizes the native binary for the specific CPU architecture of the machine where it was compiled (e.g., the GitHub Actions runner). When that binary is moved to an older CPU or a CPU with a different feature set (like missing AVX2), it fails the compatibility check.

To fix this and ensure the library is portable across different CPUs of the same architecture (and to prepare for ARM support), you need to set the -march (machine architecture) flag to compatibility.