### PR TITLE
Fix SRID with FGB

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,3 +11,4 @@
 - Improve clustering functions to load only ids- 
 - Fix CPU compatibility issues in GraalVM about https://github.com/orbisgis/h2gis/issues/1473
 - Improve ST_CLIP to process complex polygon
+- Preserve the SRID when a “SELECT ST_GEOMFROMTEXT(''POINT(0 0)'', 4326) As the_geom” query is stored in an FGB table

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/fgb/FGBWriteDriver.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/fgb/FGBWriteDriver.java
@@ -132,7 +132,7 @@ public class FGBWriteDriver {
                     }
                     rs.beforeFirst();
                     ProgressVisitor copyProgress = progress.subProcess(recordCount);
-                    doExport(progress, rs,  spatialFieldNameAndIndex.first(), recordCount, new FileOutputStream(fileName), null);
+                    doExport(progress, rs,  spatialFieldNameAndIndex.first(), recordCount, new FileOutputStream(fileName), null, srid);
                     copyProgress.endOfProgress();
                     return fileName.getAbsolutePath();
                 } else {
@@ -180,7 +180,7 @@ public class FGBWriteDriver {
                     Tuple<String, GeometryMetaData> geomMetadata = GeometryTableUtilities.getFirstColumnMetaData(connection, parse);
                     String geomCol = geomMetadata.first();
                     ResultSet rs = st.executeQuery(String.format("select * from %s", outputTable));
-                    doExport(progress, rs, geomCol, recordCount, outputStream, fileNameWithoutExt);
+                    doExport(progress, rs, geomCol, recordCount, outputStream, fileNameWithoutExt, geomMetadata.second().SRID);
                 }
 
         } finally {
@@ -194,12 +194,12 @@ public class FGBWriteDriver {
         }
     }
 
-    private String doExport(ProgressVisitor progress, ResultSet rs, String geometryColumn,  int recordCount, FileOutputStream outputStream, String fileName) throws SQLException, IOException {
+    private String doExport(ProgressVisitor progress, ResultSet rs, String geometryColumn,  int recordCount, FileOutputStream outputStream, String fileName, int srid) throws SQLException, IOException {
 
         FlatBufferBuilder bufferBuilder = new FlatBufferBuilder();
 
         //Write the header
-        HeaderMeta header = writeHeader(outputStream, fileName, bufferBuilder, recordCount, geometryColumn, rs.getMetaData());
+        HeaderMeta header = writeHeader(outputStream, fileName, bufferBuilder, recordCount, geometryColumn, rs.getMetaData(), srid);
 
         long endHeaderPosition = outputStream.getChannel().position();
         //Columns numbers
@@ -357,9 +357,10 @@ public class FGBWriteDriver {
      * @param fileName name of the file
      * @param rowCount number of rows
      * @param metadata flatbuffer metadata
+     * @param srid srid value
      * @return flatbuffer header object
      */
-    private HeaderMeta writeHeader(FileOutputStream outputStream, String fileName, FlatBufferBuilder bufferBuilder, long rowCount, String geometryColumn, ResultSetMetaData metadata) throws SQLException, IOException {
+    private HeaderMeta writeHeader(FileOutputStream outputStream, String fileName, FlatBufferBuilder bufferBuilder, long rowCount, String geometryColumn, ResultSetMetaData metadata, int srid) throws SQLException, IOException {
         outputStream.write(Constants.MAGIC_BYTES);
         HeaderMeta headerMeta = new HeaderMeta();
         //Get the column information
@@ -374,7 +375,11 @@ public class FGBWriteDriver {
                     headerMeta.hasZ = geomMeta.hasZ;
                     headerMeta.hasM = geomMeta.hasM;
                     headerMeta.geometryType = geometryType(geomMeta.geometryType);
-                    headerMeta.srid = geomMeta.SRID;
+                    if(srid==0){
+                        headerMeta.srid = geomMeta.SRID;
+                    }else {
+                        headerMeta.srid = srid;
+                    }
                 }
                 continue;
             }

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/fgb/FGBImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/fgb/FGBImportExportTest.java
@@ -5,6 +5,7 @@ import org.h2.value.Value;
 import org.h2.value.ValueVarchar;
 import org.h2gis.functions.factory.H2GISDBFactory;
 import org.h2gis.functions.io.fgb.fileTable.FGBDriver;
+import org.h2gis.utilities.GeometryTableUtilities;
 import org.h2gis.utilities.JDBCUtilities;
 import org.h2gis.utilities.URIUtilities;
 import org.junit.jupiter.api.AfterAll;
@@ -545,6 +546,19 @@ public class FGBImportExportTest {
             assertEquals(10.25, rs.getFloat("area"), 10-2);
             assertFalse(rs.getBoolean("boolean_col"));
             assertFalse(rs.next());
+        }
+    }
+
+    @Test
+    public void testSaveSelectSrid(@TempDir File temporaryDirectory) throws Exception {
+        File file = new File(temporaryDirectory, "select_srid.fgb");
+        file.deleteOnExit();
+        try (Statement stat = connection.createStatement()) {
+            stat.execute("CALL FGBWrite('"+file+"', '(SELECT ST_GEOMFROMTEXT(''POINT(0 0)'', 4326) As the_geom, 1 as id)', true);");
+            stat.execute("DROP TABLE IF EXISTS TABLE_POINTS");
+            stat.execute("CALL FGBRead('"+file+"', 'TABLE_POINTS', true);");
+            assertEquals(1, JDBCUtilities.getRowCount(connection,"TABLE_POINTS"));
+            assertEquals(4326, GeometryTableUtilities.getSRID(connection,"TABLE_POINTS"));
         }
     }
 }


### PR DESCRIPTION
Preserve the SRID when a "SELECT ST_GEOMFROMTEXT(''POINT(0 0)'', 4326) As the_geom" query is stored in an FGB table