### PR TITLE
Fix ST_SubDivide with empty geometry

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Fix CPU compatibility issues in GraalVM about https://github.com/orbisgis/h2gis/issues/1473
 - Improve ST_CLIP to process complex polygon
 - Preserve the SRID when a “SELECT ST_GEOMFROMTEXT(''POINT(0 0)'', 4326) As the_geom” query is stored in an FGB table
+- Fix ST_SubDivide with empty geometry

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/split/ST_SubDivide.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/split/ST_SubDivide.java
@@ -35,6 +35,12 @@ public class ST_SubDivide extends DeterministicScalarFunction {
      * @return Geometry
      */
     public static Geometry divide(Geometry geom, int maxvertices) {
+        if(geom ==null){
+            return null;
+        }
+        if(geom.isEmpty()){
+            return geom;
+        }
         Geometry res = FACTORY.buildGeometry(subdivide_recursive(geom, maxvertices));
         res.setSRID(geom.getSRID());
         return res;
@@ -52,11 +58,17 @@ public class ST_SubDivide extends DeterministicScalarFunction {
         if(geom ==null){
             return null;
         }
+        if (geom.isEmpty()){
+            return null;
+        }
         maxvertices = Math.max(0, maxvertices);
         Stack<Geometry> stack = new Stack<>();
         int size = geom.getNumGeometries();
         for (int i = 0; i < size; i++) {
-            stack.add(geom.getGeometryN(i));
+            Geometry subGeom = geom.getGeometryN(i);
+            if(!subGeom.isEmpty()) {
+                stack.add(subGeom);
+            }
         }
         List<Geometry> results = new ArrayList<>();
         while (!stack.isEmpty()) {
@@ -114,11 +126,14 @@ public class ST_SubDivide extends DeterministicScalarFunction {
         if(geom ==null){
             return null;
         }
+        if(geom.isEmpty()){
+            return geom;
+        }
         List<Geometry> results = new ArrayList();
         int size = geom.getNumGeometries();
         for (int i = 0; i < size; i++) {
             Geometry subGeom = geom.getGeometryN(i);
-            if (subGeom instanceof Polygon || subGeom instanceof LineString) {
+            if (!subGeom.isEmpty() && (subGeom instanceof Polygon || subGeom instanceof LineString)) {
                 final Envelope envelope = subGeom.getEnvelopeInternal();
                 double minX = envelope.getMinX();
                 double maxX = envelope.getMaxX();

--- a/h2gis-functions/src/test/java/org/h2gis/functions/spatial/SpatialFunction2Test.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/spatial/SpatialFunction2Test.java
@@ -24,8 +24,10 @@ package org.h2gis.functions.spatial;
 import org.h2.jdbc.JdbcSQLException;
 import org.h2.jdbc.JdbcSQLNonTransientException;
 import org.h2gis.functions.factory.H2GISDBFactory;
+import org.h2gis.functions.spatial.split.ST_SubDivide;
 import org.junit.jupiter.api.*;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.WKTReader;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -1220,6 +1222,15 @@ public class SpatialFunction2Test {
         assertGeometryEquals("SRID=4326;MULTILINESTRING ((-200 200, 0 200), (0 200, 200 200))",
                 rs.getObject(1));
         rs.close();
+    }
+
+    @Test
+    public void test_ST_SUBDIVIDE8() throws Exception {
+        WKTReader wktReader =  new WKTReader();
+        Geometry geom = wktReader.read("MULTIPOLYGON (EMPTY, \n" +
+                "  ((210 140, 280 140, 280 100, 210 100, 210 140)))");
+        Geometry res =  ST_SubDivide.divide(geom);
+        assertEquals(5, res.getNumGeometries());
     }
 
     @Test


### PR DESCRIPTION
ST_SubDivide now allows empty geometry 

e.g 

MULTIPOLYGON (EMPTY, 
  ((210 140, 280 140, 280 100, 210 100, 210 140)))