### PR TITLE
Add of a new parameter, "angle", to ST_Make_grid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,3 +13,4 @@
 - Improve ST_CLIP to process complex polygon
 - Preserve the SRID when a “SELECT ST_GEOMFROMTEXT(''POINT(0 0)'', 4326) As the_geom” query is stored in an FGB table
 - Fix ST_SubDivide with empty geometry, improve performance
+- Fix ST_ClustersTest with String.format 

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/DriverManager.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/DriverManager.java
@@ -38,6 +38,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
+import java.util.Locale;
 
 /**
  * Manage additional table engines in H2.
@@ -97,7 +98,8 @@ public class DriverManager extends AbstractFunction implements ScalarFunction, D
             if(driverDef.getFileExt().equalsIgnoreCase(ext)) {
                 try (Statement st = connection.createStatement()) {
                     String tableName_ = TableLocation.parse(tableName, dbType).toString();
-                    st.execute(String.format("CREATE TABLE %s COMMENT %s ENGINE %s WITH %s",
+                    st.execute(String.format(Locale.ROOT,
+                            "CREATE TABLE %s COMMENT %s ENGINE %s WITH %s",
                             tableName_,StringUtils.quoteStringSQL(fileName),
                             StringUtils.quoteJavaString(driverDef.getClassName()),StringUtils.quoteJavaString(fileName)));
                      return new String[]{tableName_};

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/dbf/DBFDriverFunction.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/dbf/DBFDriverFunction.java
@@ -41,6 +41,7 @@ import java.nio.file.Files;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.h2gis.utilities.FileUtilities;
@@ -129,14 +130,14 @@ public class DBFDriverFunction implements DriverFunction {
                 JDBCUtilities.attachCancelResultSet(st, progress);
                 ProgressVisitor lineProgress = null;
                 if (!(progress instanceof EmptyProgressVisitor)) {
-                    try (ResultSet rs = st.executeQuery(String.format("select count(*) from %s", outputTable))) {
+                    try (ResultSet rs = st.executeQuery(String.format(Locale.ROOT, "select count(*) from %s", outputTable))) {
                         if (rs.next()) {
                             lineProgress = progress.subProcess(rs.getInt(1));
                         }
                     }
                 }
                 try {
-                    try (ResultSet rs = st.executeQuery(String.format("select * from %s", outputTable))) {
+                    try (ResultSet rs = st.executeQuery(String.format(Locale.ROOT, "select * from %s", outputTable))) {
                         ResultSetMetaData resultSetMetaData = rs.getMetaData();
                         ArrayList<Integer> columnIndexes = new ArrayList<Integer>();
                         DbaseFileHeader header = dBaseHeaderFromMetaData(resultSetMetaData, columnIndexes);
@@ -244,14 +245,14 @@ public class DBFDriverFunction implements DriverFunction {
                         List<Column> otherCols = new ArrayList<>(dbfHeader.getNumFields() + 1);
                         String types = getSQLColumnTypes(dbfHeader, DBUtils.getDBType(connection), otherCols);
                         String pkColName = FileEngine.getUniqueColumnName(H2TableIndex.PK_COLUMN_NAME, otherCols);
-                        st.execute(String.format("CREATE TABLE %s (" + pkColName + " INT PRIMARY KEY, %s)", outputTable,
+                        st.execute(String.format(Locale.ROOT, "CREATE TABLE %s (" + pkColName + " INT PRIMARY KEY, %s)", outputTable,
                                 types));
                     }
                     try {
                         connection.setAutoCommit(false);
                         int columnCount = dbfDriver.getFieldCount();
                         try (PreparedStatement preparedStatement = connection.prepareStatement(
-                                String.format("INSERT INTO %s VALUES ( %s )", outputTable,
+                                String.format(Locale.ROOT, "INSERT INTO %s VALUES ( %s )", outputTable,
                                         getQuestionMark(dbfHeader.getNumFields() + 1)))) {
                             JDBCUtilities.attachCancelResultSet(preparedStatement, progress);
                             long batchSize = 0;

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/fgb/FGBWriteDriver.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/fgb/FGBWriteDriver.java
@@ -54,6 +54,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -179,7 +180,7 @@ public class FGBWriteDriver {
                       Statement st = connection.createStatement()) {
                     Tuple<String, GeometryMetaData> geomMetadata = GeometryTableUtilities.getFirstColumnMetaData(connection, parse);
                     String geomCol = geomMetadata.first();
-                    ResultSet rs = st.executeQuery(String.format("select * from %s", outputTable));
+                    ResultSet rs = st.executeQuery(String.format(Locale.ROOT, "select * from %s", outputTable));
                     doExport(progress, rs, geomCol, recordCount, outputStream, fileNameWithoutExt, geomMetadata.second().SRID);
                 }
 

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonWriteDriver.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/geojson/GeoJsonWriteDriver.java
@@ -33,6 +33,7 @@ import java.io.*;
 import java.nio.file.Files;
 import java.sql.*;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -264,7 +265,7 @@ public class GeoJsonWriteDriver {
                     writeCRS(jsonGenerator, GeometryTableUtilities.getAuthorityAndSRID(connection, parse, geometryTableInfo.first()));
                     jsonGenerator.writeArrayFieldStart("features");
 
-                    ResultSet rs = st.executeQuery(String.format("select * from %s", tableName));
+                    ResultSet rs = st.executeQuery(String.format(Locale.ROOT, "select * from %s", tableName));
 
                     try {
                         ResultSetMetaData resultSetMetaData = rs.getMetaData();

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/json/JsonWriteDriver.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/json/JsonWriteDriver.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.nio.file.Files;
 import java.sql.*;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPOutputStream;
@@ -274,7 +275,7 @@ public class JsonWriteDriver {
                       Statement st = connection.createStatement()) {
                     JsonFactory jsonFactory = new JsonFactory();
                     JsonGenerator jsonGenerator = jsonFactory.createGenerator(new BufferedOutputStream(fos), jsonEncoding);
-                    ResultSet rs = st.executeQuery(String.format("select * from %s", outputTable));
+                    ResultSet rs = st.executeQuery(String.format(Locale.ROOT, "select * from %s", outputTable));
                     try {
                         ResultSetMetaData rsmd = rs.getMetaData();
                         int numColumns = rsmd.getColumnCount();

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/kml/KMLWriterDriver.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/kml/KMLWriterDriver.java
@@ -30,6 +30,7 @@ import java.io.*;
 import java.nio.file.Files;
 import java.sql.*;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -120,7 +121,7 @@ public class KMLWriterDriver {
         } else {
                 //Write table
                 Statement st = connection.createStatement() ;
-                ResultSet resultSet = st.executeQuery(String.format("select * from %s", tableName));
+                ResultSet resultSet = st.executeQuery(String.format(Locale.ROOT, "select * from %s", tableName));
                 // Read Geometry Index and type
                 Tuple<String, Integer> spatialFieldName = GeometryTableUtilities.getFirstGeometryColumnNameAndIndex(resultSet);
                 this.tableName=tableName;

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/shp/SHPDriverFunction.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/shp/SHPDriverFunction.java
@@ -44,6 +44,7 @@ import java.nio.file.Files;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -129,7 +130,7 @@ public class SHPDriverFunction implements DriverFunction {
             Tuple<String, Integer> spatialFieldNameAndIndex = GeometryTableUtilities.getFirstGeometryColumnNameAndIndex(connection, tableLocation);
             Statement st = connection.createStatement();
             JDBCUtilities.attachCancelResultSet(st, progress);
-            ResultSet rs = st.executeQuery(String.format("select * from %s", location));
+            ResultSet rs = st.executeQuery(String.format(Locale.ROOT, "select * from %s", location));
             String[] files = doExport(connection, spatialFieldNameAndIndex.second(), rs, recordCount, fileName, copyProgress, options);
             copyProgress.endOfProgress();
             return files;
@@ -308,13 +309,13 @@ public class SHPDriverFunction implements DriverFunction {
                     String pkColName = FileEngine.getUniqueColumnName(H2TableIndex.PK_COLUMN_NAME, otherCols);
                     srid = PRJUtil.getSRID(shpDriver.prjFile);
                     shpDriver.setSRID(srid);
-                    st.execute(String.format("CREATE TABLE %s (" + pkColName + " INT PRIMARY KEY , the_geom GEOMETRY(%s, %d) %s)", requestedTable,
+                    st.execute(String.format(Locale.ROOT, "CREATE TABLE %s (" + pkColName + " INT PRIMARY KEY , the_geom GEOMETRY(%s, %d) %s)", requestedTable,
                                 getSFSGeometryType(shpHeader), srid, types));
 
                 }
                 try {
                     connection.setAutoCommit(false);
-                    lastSql = String.format("INSERT INTO %s VALUES (?, %s )", outputTableName,
+                    lastSql = String.format(Locale.ROOT, "INSERT INTO %s VALUES (?, %s )", outputTableName,
                             DBFDriverFunction.getQuestionMark(dbfNumFields + 1));
                     final int columnCount = dbfNumFields+1;
                     connection.setAutoCommit(false);

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/tsv/TSVDriverFunction.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/tsv/TSVDriverFunction.java
@@ -30,6 +30,7 @@ import java.io.*;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.sql.*;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
@@ -248,7 +249,7 @@ public class TSVDriverFunction implements DriverFunction {
         Csv csv = new Csv();
         String csvOptions = "charset=UTF-8 fieldSeparator=\t fieldDelimiter=\t";
         if (encoding != null) {
-            csvOptions = String.format("charset=%s fieldSeparator=\t fieldDelimiter=\t", encoding);
+            csvOptions = String.format(Locale.ROOT, "charset=%s fieldSeparator=\t fieldDelimiter=\t", encoding);
         }
         csv.setOptions(csvOptions);
         csv.write(writer, res);

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/utility/IOMethods.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/utility/IOMethods.java
@@ -211,7 +211,8 @@ public class IOMethods {
                     }
 
                     try (Statement statement = targetConnection.createStatement()) {
-                        statement.execute(String.format("CREATE LINKED TABLE %s('%s', '%s', '%s', '%s', '%s') FETCH_SIZE %s %s",
+                        statement.execute(String.format(Locale.ROOT, 
+                                "CREATE LINKED TABLE %s('%s', '%s', '%s', '%s', '%s') FETCH_SIZE %s %s",
                                 ouputTableName, driverName, jdbc_url, user, password, sourceTable, fetchSize, autocommit_linkedTable));
                         if (!targetConnection.getAutoCommit()) {
                             targetConnection.commit();
@@ -277,7 +278,7 @@ public class IOMethods {
 
         try {
             try (Statement statement = connection.createStatement()) {
-                statement.execute(String.format("CALL FILE_TABLE('%s','%s')", filePath, tableName));
+                statement.execute(String.format(Locale.ROOT, "CALL FILE_TABLE('%s','%s')", filePath, tableName));
                 if (!connection.getAutoCommit()) {
                     connection.commit();
                 }

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/clusters/ClusterDBSCAN.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/clusters/ClusterDBSCAN.java
@@ -103,7 +103,7 @@ public class ClusterDBSCAN extends AbstractCluster {
         }
 
         // Materialise pairs once (CACHED = B-tree on disk, no OOM risk)
-        String createPairsSql = String.format(
+        String createPairsSql = String.format(Locale.ROOT,
                 "CREATE CACHED LOCAL TEMPORARY TABLE tmp_pairs AS " +
                         "SELECT a.%s AS id_a, b.%s AS id_b " +
                         "FROM %s a, %s b " +

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/clusters/ClusterDBSCAN.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/clusters/ClusterDBSCAN.java
@@ -124,7 +124,7 @@ public class ClusterDBSCAN extends AbstractCluster {
 
         try {
             // Identify core points from tmp_pairs
-            String corePointSql = String.format(
+            String corePointSql = String.format(Locale.ROOT,
                     "SELECT id, COUNT(*) AS cnt " +
                             "FROM ( " +
                             "  SELECT id_a AS id FROM tmp_pairs " +

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/clusters/ClusterIntersecting.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/clusters/ClusterIntersecting.java
@@ -93,7 +93,7 @@ public class ClusterIntersecting extends AbstractCluster {
             parent[i] = i;
         }
 
-        String pairSql = String.format(
+        String pairSql = String.format(Locale.ROOT,
                 "SELECT a.%s, b.%s " +
                         "FROM %s a, %s b " +
                         "WHERE a.%s < b.%s " +

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/clusters/ClusterWithin.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/clusters/ClusterWithin.java
@@ -97,7 +97,7 @@ public class ClusterWithin extends AbstractCluster {
         for (int i = 0; i < n; i++) {
             parent[i] = i;
         }
-        String pairSql = String.format(
+        String pairSql = String.format(Locale.ROOT,
                 "SELECT a.%s, b.%s " +
                         "FROM %s a, %s b " +
                         "WHERE a.%s < b.%s " +

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/create/GridRowSet.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/create/GridRowSet.java
@@ -24,6 +24,7 @@ import org.h2.tools.SimpleRowSource;
 import org.h2gis.utilities.TableLocation;
 import org.h2gis.utilities.dbtypes.DBUtils;
 import org.locationtech.jts.geom.*;
+import org.locationtech.jts.geom.util.AffineTransformation;
 
 import java.sql.*;
 import org.cts.util.UTMUtils;
@@ -57,6 +58,10 @@ public class GridRowSet implements SimpleRowSource {
     private int srid;
     private boolean isRowColumnNumber =false;
     private boolean upperCornerOrder=false;
+    private Coordinate pivot;
+    private double angle = 0;
+    private static AffineTransformation rotateGeom;
+    private boolean angleUpdated = false;
 
     /**
      * The grid will be computed according a table stored in the database
@@ -65,13 +70,17 @@ public class GridRowSet implements SimpleRowSource {
      * @param deltaX x size
      * @param deltaY y size
      * @param tableName table name
+     * @param angle the rotation in radian
      */
-    public GridRowSet(Connection connection, double deltaX, double deltaY, String tableName) {
+    public GridRowSet(Connection connection, double deltaX, double deltaY, String tableName, double angle) {
         this.connection = connection;
         this.deltaX = deltaX;
         this.deltaY = deltaY;
         this.tableName = tableName;
         this.isTable = true;
+        this.pivot = new Coordinate();
+        this.angleUpdated = true;
+        this.angle = angle%(Math.PI*2);
     }
 
     /**
@@ -81,13 +90,26 @@ public class GridRowSet implements SimpleRowSource {
      * @param deltaX x size
      * @param deltaY y size
      * @param geometry {@link Geometry}
+     * @param angle the rotation in radian
      */
-    public GridRowSet(Connection connection, double deltaX, double deltaY, Geometry geometry) {
+    public GridRowSet(Connection connection, double deltaX, double deltaY, Geometry geometry, double angle) {
         this.connection = connection;
         this.deltaX = deltaX;
         this.deltaY = deltaY;
         this.srid = geometry.getSRID();
-        this.envelope = geometry.getEnvelopeInternal();
+        this.pivot = new Coordinate();
+        this.angleUpdated = true;
+        this.angle = angle%(Math.PI*2);
+
+        if(this.angle > 0.0001 || this.angle < -0.0001 ){
+            Envelope envelopeGeom = geometry.getEnvelopeInternal();
+            this.pivot = envelopeGeom.centre();
+            Geometry envelopeRotated = AffineTransformation.rotationInstance(angle, pivot.getX(), pivot.getY()).transform(geometry);
+            Geometry envelopeUnRotated = AffineTransformation.rotationInstance(-angle, pivot.getX(), pivot.getY()).transform(GF.toGeometry(envelopeRotated.getEnvelopeInternal()));
+            this.envelope = envelopeUnRotated.getEnvelopeInternal();
+        }else{
+            this.envelope = geometry.getEnvelopeInternal();
+        }
         this.isTable = false;
     }
 
@@ -111,10 +133,14 @@ public class GridRowSet implements SimpleRowSource {
                 return new Object[]{getCellPoint(), id++, cellI, cellJ + 1};
             }
         }
-        if(upperCornerOrder){
-            return new Object[]{getCellPolygonUpper(), id++, cellI, cellJ + 1};
+        if(this.angleUpdated){
+            rotateGeom = AffineTransformation.rotationInstance(angle, pivot.getX(),pivot.getY());
+            this.angleUpdated = false;
         }
-        return new Object[]{getCellPolygon(), id++, cellI, cellJ + 1};
+        if(upperCornerOrder){
+            return new Object[]{rotateGeom.transform(getCellPolygonUpper()), id++, cellI, cellJ + 1};
+        }
+        return new Object[]{rotateGeom.transform(getCellPolygon()), id++, cellI, cellJ + 1};
     }
 
     @Override
@@ -138,7 +164,16 @@ public class GridRowSet implements SimpleRowSource {
                 if (geomExtend == null) {
                     throw new SQLException("The envelope cannot be null.");
                 } else {
-                    envelope = geomExtend.getEnvelopeInternal();
+                    if(this.angle > 0.0001 || this.angle < -0.0001 ){
+                        Envelope envelopeGeom = geomExtend.getEnvelopeInternal();
+                        pivot = envelopeGeom.centre();
+                        Geometry envelopeRotated = AffineTransformation.rotationInstance(angle, pivot.getX(), pivot.getY()).transform(geomExtend);
+                        Geometry envelopeUnRotated = AffineTransformation.rotationInstance(-angle, pivot.getX(), pivot.getY()).transform(GF.toGeometry(envelopeRotated.getEnvelopeInternal()));
+                        envelope = envelopeUnRotated.getEnvelopeInternal();
+
+                    }else{
+                        envelope = geomExtend.getEnvelopeInternal();
+                    }
                     initParameters();
                 }
 

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/create/ST_MakeGrid.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/create/ST_MakeGrid.java
@@ -21,7 +21,9 @@
 package org.h2gis.functions.spatial.create;
 
 import org.h2.value.Value;
+import org.h2.value.ValueBoolean;
 import org.h2.value.ValueGeometry;
+import org.h2.value.ValueNumeric;
 import org.h2.value.ValueVarchar;
 import org.h2gis.api.AbstractFunction;
 import org.h2gis.api.ScalarFunction;
@@ -65,29 +67,31 @@ public class ST_MakeGrid extends AbstractFunction implements ScalarFunction {
      * @return a resultset that contains all cells as a set of polygons
      */
     public static ResultSet createGrid(Connection connection, Value value, double deltaX, double deltaY) throws SQLException {
-            return createGrid( connection,  value,  deltaX,  deltaY, false) ;
+            return createGrid( connection,  value,  deltaX,  deltaY, false, 0) ;
         }
-        /**
-         * Create a regular grid using the first input argument to compute the full
-         * extent.
-         *
-         * @param connection database     * @param value could be the name of a table or a geometry.
-         * @param deltaX the X cell size
-         * @param deltaY the Y cell size
-         * @param upperOrder start the cell from the upper left corner
-         * @return a resultset that contains all cells as a set of polygons
-         */
-    public static ResultSet createGrid(Connection connection, Value value, double deltaX, double deltaY, boolean upperOrder) throws SQLException {
+
+    /**
+     * Create a regular grid using the first input argument to compute the full
+     * extent.
+     *
+     * @param connection database     * @param value could be the name of a table or a geometry.
+     * @param deltaX the X cell size
+     * @param deltaY the Y cell size
+     * @param upperOrder start the cell from the upper left corner
+     * @param angle the rotation in radian
+     * @return a resultset that contains all cells as a set of polygons
+     */
+    public static ResultSet createGrid(Connection connection, Value value, double deltaX, double deltaY, boolean upperOrder, double angle) throws SQLException {
         if(value == null){
             return null;
         }
         if (value instanceof ValueVarchar) {
-            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, value.getString());
+            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, value.getString(), angle);
             gridRowSet.setUpperOrder(upperOrder);
             return gridRowSet.getResultSet();
         } else if (value instanceof ValueGeometry) {
             ValueGeometry geom = (ValueGeometry) value;
-            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, geom.getGeometry());
+            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, geom.getGeometry(), angle);
             gridRowSet.setUpperOrder(upperOrder);
             return gridRowSet.getResultSet();
         } else {
@@ -99,26 +103,69 @@ public class ST_MakeGrid extends AbstractFunction implements ScalarFunction {
      * Create a regular grid using the first input argument to compute the full
      * extent.
      *
+     * @param connection database     * @param value could be the name of a table or a geometry.
+     * @param deltaX the X cell size
+     * @param deltaY the Y cell size
+     * @param valueAngleOrder could be the boolean to indicate the start from the upper left corner or the angle in rotation in radian
+     * @return a resultset that contains all cells as a set of polygons
+     */
+    public static ResultSet createGrid(Connection connection, Value value, double deltaX, double deltaY, Value valueAngleOrder) throws SQLException {
+        if(value == null){
+            return null;
+        }
+        double angle;
+        boolean upperOrder;
+        if(valueAngleOrder instanceof ValueBoolean){
+            angle = 0;
+            upperOrder = valueAngleOrder.getBoolean();
+        }else if (valueAngleOrder instanceof ValueNumeric){
+            upperOrder = false;
+            angle = valueAngleOrder.getDouble();
+        }else {
+            throw new SQLException("This function supports only angle or a boolean as last argument.");
+        }
+
+        if (value instanceof ValueVarchar) {
+            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, value.getString(), angle);
+            gridRowSet.setUpperOrder(upperOrder);
+            return gridRowSet.getResultSet();
+        } else if (value instanceof ValueGeometry) {
+            ValueGeometry geom = (ValueGeometry) value;
+            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, geom.getGeometry(), angle);
+            gridRowSet.setUpperOrder(upperOrder);
+            return gridRowSet.getResultSet();
+        } else {
+            throw new SQLException("This function supports only table name or geometry as first argument.");
+        }
+    }
+
+
+
+    /**
+     * Create a regular grid using the first input argument to compute the full
+     * extent.
+     *
      * @param connection database
      * @param value could be the name of a table or a geometry.
      * @param deltaX the X cell size
      * @param deltaY the Y cell size
      * @param upperOrder start the cell from the upper left corner
      * @param isColumnsRowsMeasure deltaX and deltaY refer to the number of columns and rows
+     * @param angle the rotation in radian
      * @return a resultset that contains all cells as a set of polygons
      */
-    public static ResultSet createGrid(Connection connection, Value value, double deltaX, double deltaY, boolean upperOrder, boolean isColumnsRowsMeasure) throws SQLException {
+    public static ResultSet createGrid(Connection connection, Value value, double deltaX, double deltaY, boolean upperOrder, boolean isColumnsRowsMeasure, double angle) throws SQLException {
         if(value == null){
             return null;
         }
         if (value instanceof ValueVarchar) {
-            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, value.getString());
+            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, value.getString(), angle);
             gridRowSet.setIsRowColumnNumber(isColumnsRowsMeasure);
             gridRowSet.setUpperOrder(upperOrder);
             return gridRowSet.getResultSet();
         } else if (value instanceof ValueGeometry) {
             ValueGeometry geom = (ValueGeometry) value;
-            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, geom.getGeometry());
+            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, geom.getGeometry(), angle);
             gridRowSet.setIsRowColumnNumber(isColumnsRowsMeasure);
             gridRowSet.setUpperOrder(upperOrder);
             return gridRowSet.getResultSet();
@@ -126,4 +173,5 @@ public class ST_MakeGrid extends AbstractFunction implements ScalarFunction {
             throw new SQLException("This function supports only table name or geometry as first argument.");
         }
     }
+
 }

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/create/ST_MakeGridPoints.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/create/ST_MakeGridPoints.java
@@ -63,27 +63,28 @@ public class ST_MakeGridPoints extends AbstractFunction implements ScalarFunctio
     public static ResultSet createGridPoints(Connection connection, Value value, double deltaX, double deltaY) throws SQLException {
             return createGridPoints(connection,  value, deltaX, deltaY, false);
     }
-        /**
-         * Create a regular grid of points using the first input value to compute
-         * the full extent.
-         *
-         * @param connection database     * @param value could be the name of a table or a geometry.
-         * @param deltaX the X cell size
-         * @param deltaY the Y cell size
-         * @return a resultset that contains all cells as a set of polygons
-         */
+
+    /**
+     * Create a regular grid of points using the first input value to compute
+     * the full extent.
+     *
+     * @param connection database     * @param value could be the name of a table or a geometry.
+     * @param deltaX the X cell size
+     * @param deltaY the Y cell size
+     * @return a resultset that contains all cells as a set of polygons
+     */
     public static ResultSet createGridPoints(Connection connection, Value value, double deltaX, double deltaY, boolean upperOrder) throws SQLException {
         if(value == null){
             return null;
         }
         if (value instanceof ValueVarchar) {
-            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, value.getString());
+            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, value.getString(), 0); //Rajouter angle ? // Ça fonctionne cela ?
             gridRowSet.setCenterCell(true);
             gridRowSet.setUpperOrder(upperOrder);
             return gridRowSet.getResultSet();
         } else if (value instanceof ValueGeometry) {
             ValueGeometry geom = (ValueGeometry) value;
-            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, geom.getGeometry());
+            GridRowSet gridRowSet = new GridRowSet(connection, deltaX, deltaY, geom.getGeometry(), 0);
             gridRowSet.setCenterCell(true);
             gridRowSet.setUpperOrder(upperOrder);
             return gridRowSet.getResultSet();

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/metadata/FindGeometryMetadata.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/metadata/FindGeometryMetadata.java
@@ -28,6 +28,7 @@ import org.h2gis.utilities.dbtypes.DBUtils;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Locale;
 
 public class FindGeometryMetadata extends DeterministicScalarFunction{
 
@@ -68,7 +69,7 @@ public class FindGeometryMetadata extends DeterministicScalarFunction{
         String[] values = new String[4];
         if(srid==null) {
             try ( ResultSet rs = connection.createStatement()
-                    .executeQuery(String.format("select ST_SRID(%s) from %s LIMIT 1;",
+                    .executeQuery(String.format(Locale.ROOT, "select ST_SRID(%s) from %s LIMIT 1;",
                             StringUtils.quoteJavaString(columnName),
                             new TableLocation(catalogName, schemaName, tableName, DBUtils.getDBType(connection))))) {
                 if (rs.next()) {

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/asc/AscReaderDriverTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/asc/AscReaderDriverTest.java
@@ -40,6 +40,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Locale;
 import java.util.Properties;
 
 import org.h2gis.unitTest.GeometryAsserts;
@@ -314,7 +315,7 @@ public class AscReaderDriverTest {
     public void testASCRead() throws IOException, SQLException {
         Statement st = connection.createStatement();
         st.execute("DROP TABLE PRECIP30MIN IF EXISTS");
-        st.execute(String.format("CALL ASCREAD('%s')",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
+        st.execute(String.format(Locale.ROOT, "CALL ASCREAD('%s')",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
 
         // Check number of extracted cells
         try(ResultSet rs = st.executeQuery("SELECT COUNT(*) CPT FROM PRECIP30MIN")) {
@@ -327,7 +328,8 @@ public class AscReaderDriverTest {
         Geometry envGeom = factory.toGeometry(env);
         envGeom.setSRID(3857);
         st.execute("DROP TABLE PRECIP30MIN IF EXISTS");
-        st.execute(String.format("CALL ASCREAD('%s', 'PRECIP30MIN', '%s'" +
+        st.execute(String.format(Locale.ROOT, 
+                "CALL ASCREAD('%s', 'PRECIP30MIN', '%s'" +
                 "::GEOMETRY , 1, TRUE)",AscReaderDriverTest.class.getResource("precip30min.asc").getFile(),
                 envGeom.toString()
                 ));
@@ -338,7 +340,7 @@ public class AscReaderDriverTest {
             assertEquals(90, rs.getInt("CPT"));
         }
         st.execute("DROP TABLE PRECIP30MIN IF EXISTS");
-        st.execute(String.format("CALL ASCREAD('%s', 'PRECIP30MIN', NULL, 5, TRUE)",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
+        st.execute(String.format(Locale.ROOT, "CALL ASCREAD('%s', 'PRECIP30MIN', NULL, 5, TRUE)",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
 
         // Check number of extracted cells
         try(ResultSet rs = st.executeQuery("SELECT COUNT(*) CPT FROM PRECIP30MIN")) {
@@ -351,7 +353,7 @@ public class AscReaderDriverTest {
     public void testASCReadPoints() throws IOException, SQLException {
         Statement st = connection.createStatement();
         st.execute("DROP TABLE PRECIP30MIN IF EXISTS");
-        st.execute(String.format("CALL ASCREAD('%s')",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
+        st.execute(String.format(Locale.ROOT, "CALL ASCREAD('%s')",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
         try(ResultSet rs = st.executeQuery("SELECT the_geom  FROM PRECIP30MIN limit 1")) {
             assertTrue(rs.next());
             GeometryAsserts.assertGeometryEquals("SRID=3857;POINT Z (-179.75 -80.25 234)", (Geometry) rs.getObject("THE_GEOM"));
@@ -392,13 +394,13 @@ public class AscReaderDriverTest {
     public void testASCReadPointsTwoTimes() throws IOException, SQLException {
         Statement st = connection.createStatement();
         st.execute("DROP TABLE PRECIP30MIN IF EXISTS");
-        st.execute(String.format("CALL ASCREAD('%s')",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
+        st.execute(String.format(Locale.ROOT, "CALL ASCREAD('%s')",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
         try(ResultSet rs = st.executeQuery("SELECT the_geom  FROM PRECIP30MIN limit 1")) {
             assertTrue(rs.next());
             GeometryAsserts.assertGeometryEquals("SRID=3857;POINT Z (-179.75 -80.25 234)", (Geometry) rs.getObject("THE_GEOM"));
         }
         st.execute("DROP TABLE PRECIP30MIN_NEXT IF EXISTS");
-        st.execute(String.format("CALL ASCREAD('%s','PRECIP30MIN_NEXT')",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
+        st.execute(String.format(Locale.ROOT, "CALL ASCREAD('%s','PRECIP30MIN_NEXT')",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
         try(ResultSet rs = st.executeQuery("SELECT the_geom  FROM PRECIP30MIN_NEXT limit 1")) {
             assertTrue(rs.next());
             GeometryAsserts.assertGeometryEquals("SRID=3857;POINT Z (-179.75 -80.25 234)", (Geometry) rs.getObject("THE_GEOM"));
@@ -409,7 +411,7 @@ public class AscReaderDriverTest {
     public void testASCReadPointsZType() throws IOException, SQLException {
         Statement st = connection.createStatement();
         st.execute("DROP TABLE PRECIP30MIN IF EXISTS");
-        st.execute(String.format("CALL ASCREAD('%s', 1)",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
+        st.execute(String.format(Locale.ROOT, "CALL ASCREAD('%s', 1)",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
         try(ResultSet rs = st.executeQuery("SELECT the_geom, z  FROM PRECIP30MIN limit 1")) {
             assertTrue(rs.next());
             GeometryAsserts.assertGeometryEquals("SRID=3857;POINT Z (-179.75 -80.25 234)", (Geometry) rs.getObject("THE_GEOM"));
@@ -417,7 +419,7 @@ public class AscReaderDriverTest {
         }
 
         st.execute("DROP TABLE PRECIP30MIN IF EXISTS");
-        st.execute(String.format("CALL ASCREAD('%s', 2)",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
+        st.execute(String.format(Locale.ROOT, "CALL ASCREAD('%s', 2)",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
         try(ResultSet rs = st.executeQuery("SELECT the_geom, z  FROM PRECIP30MIN limit 1")) {
             assertTrue(rs.next());
             GeometryAsserts.assertGeometryEquals("SRID=3857;POINT Z (-179.75 -80.25 234)", (Geometry) rs.getObject("THE_GEOM"));
@@ -425,7 +427,7 @@ public class AscReaderDriverTest {
         }
 
         st.execute("DROP TABLE PRECIP30MIN IF EXISTS");
-        st.execute(String.format("CALL ASCREAD('%s', 'mydemtable', 2)",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
+        st.execute(String.format(Locale.ROOT, "CALL ASCREAD('%s', 'mydemtable', 2)",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
         try(ResultSet rs = st.executeQuery("SELECT the_geom, z  FROM mydemtable limit 1")) {
             assertTrue(rs.next());
             GeometryAsserts.assertGeometryEquals("SRID=3857;POINT Z (-179.75 -80.25 234)", (Geometry) rs.getObject("THE_GEOM"));
@@ -433,7 +435,7 @@ public class AscReaderDriverTest {
         }
         
         st.execute("DROP TABLE PRECIP30MIN IF EXISTS");
-        st.execute(String.format("CALL ASCREAD('%s')",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
+        st.execute(String.format(Locale.ROOT, "CALL ASCREAD('%s')",AscReaderDriverTest.class.getResource("precip30min.asc").getFile()));
         try(ResultSet rs = st.executeQuery("SELECT the_geom, z  FROM PRECIP30MIN limit 1")) {
             assertTrue(rs.next());
             GeometryAsserts.assertGeometryEquals("SRID=3857;POINT Z (-179.75 -80.25 234)", (Geometry) rs.getObject("THE_GEOM"));
@@ -446,7 +448,7 @@ public class AscReaderDriverTest {
     public void testASCReadGZFile() throws IOException, SQLException {
         Statement st = connection.createStatement();
         st.execute("DROP TABLE PRECIP30MIN_ASC IF EXISTS");
-        st.execute(String.format("CALL ASCREAD('%s')",AscReaderDriverTest.class.getResource("precip30min.asc.gz").getFile()));
+        st.execute(String.format(Locale.ROOT, "CALL ASCREAD('%s')",AscReaderDriverTest.class.getResource("precip30min.asc.gz").getFile()));
         try(ResultSet rs = st.executeQuery("SELECT the_geom  FROM PRECIP30MIN_ASC limit 1")) {
             assertTrue(rs.next());
             GeometryAsserts.assertGeometryEquals("POINT Z (-179.75 -80.25 234)", (Geometry) rs.getObject("THE_GEOM"));

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/fgb/FGBImportExportTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/fgb/FGBImportExportTest.java
@@ -27,6 +27,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -523,9 +524,9 @@ public class FGBImportExportTest {
                     "numeric_col NUMERIC(10, 1),  real_col real, float_precision_col float(1), bigint_col bigint, boolean_col BOOLEAN DEFAULT FALSE )");
             stat.execute("insert into TABLE_POINTS values(1, 'POINT (140 260)', 12.10, 156.12345678, 'OrbisGIS', 1, 1,10.5,12.1234, 12.8, 1000000, true)");
             stat.execute("insert into TABLE_POINTS values(2, 'POINT (150 290)', 10.25,  156.12345678, 'NoiseModelling', null, 1,10.5,12.1234, 12.8, null, false)");
-            stat.execute(String.format("CALL FGBWrite('%s', 'TABLE_POINTS', true);", file));
+            stat.execute(String.format(Locale.ROOT, "CALL FGBWrite('%s', 'TABLE_POINTS', true);", file));
             stat.execute("DROP TABLE IF EXISTS TABLE_POINTS");
-            stat.execute(String.format("CALL FGBRead('%s', 'TABLE_POINTS', true);", file));
+            stat.execute(String.format(Locale.ROOT, "CALL FGBRead('%s', 'TABLE_POINTS', true);", file));
 
             ResultSet rs = stat.executeQuery("SELECT * FROM TABLE_POINTS");
             assertTrue(rs.next());

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/shp/SHPEngineTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/shp/SHPEngineTest.java
@@ -34,6 +34,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Locale;
 
 import static org.h2gis.unitTest.GeometryAsserts.assertGeometryEquals;
 import static org.junit.jupiter.api.Assertions.*;
@@ -359,7 +360,8 @@ public class SHPEngineTest {
         String tableName = tableLocation.getTable();
         String fieldName = TableLocation.capsIdentifier(geometryColumnName, DBTypes.H2GIS);
 
-        String query  = String.format("SELECT I.INDEX_TYPE_NAME, I.INDEX_CLASS FROM INFORMATION_SCHEMA.INDEXES AS I , " +
+        String query  = String.format(Locale.ROOT, 
+                        "SELECT I.INDEX_TYPE_NAME, I.INDEX_CLASS FROM INFORMATION_SCHEMA.INDEXES AS I , " +
                         "(SELECT COLUMN_NAME, TABLE_NAME, TABLE_SCHEMA  FROM " +
                         "INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_SCHEMA='%s' and TABLE_NAME='%s' AND COLUMN_NAME='%s') AS C " +
                         "WHERE I.TABLE_SCHEMA=C.TABLE_SCHEMA AND I.TABLE_NAME=C.TABLE_NAME and C.COLUMN_NAME='%s'"

--- a/h2gis-functions/src/test/java/org/h2gis/functions/spatial/create/CreateFunctionTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/spatial/create/CreateFunctionTest.java
@@ -459,6 +459,126 @@ public class CreateFunctionTest {
         st.execute("DROP TABLE grid;");
     }
 
+
+    @Test
+    public void testST_MakeGridFromGeometryWithAngle1() throws Exception {
+        st.execute("drop table if exists gridAngle; CREATE TABLE gridAngle AS SELECT * FROM st_makegrid('POLYGON((0 0, 2 0, 2 2, 0 0 ))'::GEOMETRY, 1, 1, false, 0.7853981634);");
+        ResultSet rs = st.executeQuery("select count(*) from gridAngle;");
+        rs.next();
+        assertEquals(rs.getInt(1), 9);
+        rs.close();
+        rs = st.executeQuery("select * from gridAngle;");
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON((1.0000000000036087 -0.4142135623730951, 0.5285954792113741 0.0571909584167337, 1.0000000000012028 0.5285954792089682, 1.4714045207934374 0.0571909584191395, 1.0000000000036087 -0.4142135623730951))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.5285954792113741 0.0571909584167337, 0.0571909584191395 0.5285954792065625, 0.5285954792089682 0.9999999999987972, 1.0000000000012028 0.5285954792089682, 0.5285954792113741 0.0571909584167337))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.0571909584191395 0.5285954792065625, -0.4142135623730951 0.9999999999963913, 0.0571909584167336 1.471404520788626, 0.5285954792089682 0.9999999999987972, 0.0571909584191395 0.5285954792065625))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON((1.4714045207934374 0.0571909584191395, 1.0000000000012028 0.5285954792089682, 1.4714045207910318 1.0000000000012028, 1.9428090415832662 0.5285954792113741, 1.4714045207934374 0.0571909584191395))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((1.0000000000012028 0.5285954792089682, 0.5285954792089682 0.9999999999987972, 0.9999999999987971 1.4714045207910316, 1.4714045207910318 1.0000000000012028, 1.0000000000012028 0.5285954792089682))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.5285954792089682 0.9999999999987972, 0.0571909584167336 1.471404520788626, 0.5285954792065625 1.9428090415808608, 0.9999999999987971 1.4714045207910316, 0.5285954792089682 0.9999999999987972))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((1.9428090415832662 0.5285954792113741, 1.4714045207910318 1.0000000000012028, 1.9428090415808605 1.4714045207934374, 2.414213562373095 1.0000000000036087, 1.9428090415832662 0.5285954792113741))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON((1.4714045207910318 1.0000000000012028, 0.9999999999987971 1.4714045207910316, 1.471404520788626 1.9428090415832664, 1.9428090415808605 1.4714045207934374, 1.4714045207910318 1.0000000000012028))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON((0.9999999999987971 1.4714045207910316, 0.5285954792065625 1.9428090415808608, 0.9999999999963913 2.414213562373095, 1.471404520788626 1.9428090415832664, 0.9999999999987971 1.4714045207910316))", rs.getObject(1));
+        rs.close();
+        st.execute("DROP TABLE grid;");
+    }
+
+    @Test
+    public void testST_MakeGridFromGeometryWithAngle2() throws Exception {
+        st.execute("drop table if exists gridAngle; CREATE TABLE gridAngle AS SELECT * FROM st_makegrid('POLYGON((0 0, 2 0, 2 2, 0 0 ))'::GEOMETRY, 1, 1, false, 1.5708);");
+        ResultSet rs = st.executeQuery("select count(*) from gridAngle;");
+        rs.next();
+        assertEquals(rs.getInt(1), 9);
+        rs.close();
+        rs = st.executeQuery("select * from gridAngle;");
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON((0 0, 0 0.6666666666666666, 0.6666666666666666 0.6666666666666666, 0.6666666666666666 0, 0 0))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0 0.6666666666666666, 0 1.3333333333333333, 0.6666666666666666 1.3333333333333333, 0.6666666666666666 0.6666666666666666, 0 0.6666666666666666))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0 1.3333333333333333, 0 2, 0.6666666666666666 2, 0.6666666666666666 1.3333333333333333, 0 1.3333333333333333))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.6666666666666666 0, 0.6666666666666666 0.6666666666666666, 1.3333333333333333 0.6666666666666666, 1.3333333333333333 0, 0.6666666666666666 0))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.6666666666666666 0.6666666666666666, 0.6666666666666666 1.3333333333333333, 1.3333333333333333 1.3333333333333333, 1.3333333333333333 0.6666666666666666, 0.6666666666666666 0.6666666666666666))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.6666666666666666 1.3333333333333333, 0.6666666666666666 2, 1.3333333333333333 2, 1.3333333333333333 1.3333333333333333, 0.6666666666666666 1.3333333333333333))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((1.3333333333333333 0, 1.3333333333333333 0.6666666666666666, 2 0.6666666666666666, 2 0, 1.3333333333333333 0))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((1.3333333333333333 0.6666666666666666, 1.3333333333333333 1.3333333333333333, 2 1.3333333333333333, 2 0.6666666666666666, 1.3333333333333333 0.6666666666666666))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((1.3333333333333333 1.3333333333333333, 1.3333333333333333 2, 2 2, 2 1.3333333333333333, 1.3333333333333333 1.3333333333333333)))", rs.getObject(1));
+        rs.close();
+        st.execute("DROP TABLE grid;");
+    }
+
+    @Test
+    public void testST_MakeGridFromGeometryWithAngle3() throws Exception {
+        st.execute("drop table if exists gridAngle; CREATE TABLE gridAngle AS SELECT * FROM st_makegrid('POLYGON((0 0, 2 0, 2 2, 0 0 ))'::GEOMETRY, 1, 1, false, 3.14159);");
+        ResultSet rs = st.executeQuery("select count(*) from gridAngle;");
+        rs.next();
+        assertEquals(rs.getInt(1), 9);
+        rs.close();
+        rs = st.executeQuery("select * from gridAngle;");
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON((0 0, 0 0.6666666666666666, 0.6666666666666666 0.6666666666666666, 0.6666666666666666 0, 0 0))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0 0.6666666666666666, 0 1.3333333333333333, 0.6666666666666666 1.3333333333333333, 0.6666666666666666 0.6666666666666666, 0 0.6666666666666666))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0 1.3333333333333333, 0 2, 0.6666666666666666 2, 0.6666666666666666 1.3333333333333333, 0 1.3333333333333333))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.6666666666666666 0, 0.6666666666666666 0.6666666666666666, 1.3333333333333333 0.6666666666666666, 1.3333333333333333 0, 0.6666666666666666 0))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.6666666666666666 0.6666666666666666, 0.6666666666666666 1.3333333333333333, 1.3333333333333333 1.3333333333333333, 1.3333333333333333 0.6666666666666666, 0.6666666666666666 0.6666666666666666))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.6666666666666666 1.3333333333333333, 0.6666666666666666 2, 1.3333333333333333 2, 1.3333333333333333 1.3333333333333333, 0.6666666666666666 1.3333333333333333))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((1.3333333333333333 0, 1.3333333333333333 0.6666666666666666, 2 0.6666666666666666, 2 0, 1.3333333333333333 0))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((1.3333333333333333 0.6666666666666666, 1.3333333333333333 1.3333333333333333, 2 1.3333333333333333, 2 0.6666666666666666, 1.3333333333333333 0.6666666666666666))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((1.3333333333333333 1.3333333333333333, 1.3333333333333333 2, 2 2, 2 1.3333333333333333, 1.3333333333333333 1.3333333333333333)))", rs.getObject(1));
+        rs.close();
+        st.execute("DROP TABLE grid;");
+    }
+
+    public void testST_MakeGridFromGeometryWithAngleNegative() throws Exception {
+        st.execute("drop table if exists gridAngle; CREATE TABLE gridAngle AS SELECT * FROM st_makegrid('POLYGON((0 0, 2 0, 2 2, 0 0 ))'::GEOMETRY, 1, 1, false, -0.7853981634);");
+        ResultSet rs = st.executeQuery("select count(*) from gridAngle;");
+        rs.next();
+        assertEquals(rs.getInt(1), 9);
+        rs.close();
+        rs = st.executeQuery("select * from gridAngle;");
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((-0.4142135623730951 1.0000000000036087, 0.0571909584191395 1.4714045207934374, 0.5285954792089682 1.0000000000012028, 0.0571909584167337 0.5285954792113741, -0.4142135623730951 1.0000000000036087))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.0571909584191395 1.4714045207934374, 0.5285954792113741 1.9428090415832662, 1.0000000000012028 1.4714045207910318, 0.5285954792089682 1.0000000000012028, 0.0571909584191395 1.4714045207934374))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.5285954792113741 1.9428090415832662, 1.0000000000036087 2.414213562373095, 1.4714045207934374 1.9428090415808605, 1.0000000000012028 1.4714045207910318, 0.5285954792113741 1.9428090415832662))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.0571909584167337 0.5285954792113741, 0.5285954792089682 1.0000000000012028, 0.9999999999987972 0.5285954792089682, 0.5285954792065625 0.0571909584191395, 0.0571909584167337 0.5285954792113741))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.5285954792089682 1.0000000000012028, 1.0000000000012028 1.4714045207910318, 1.4714045207910316 0.9999999999987971, 0.9999999999987972 0.5285954792089682, 0.5285954792089682 1.0000000000012028))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((1.0000000000012028 1.4714045207910318, 1.4714045207934374 1.9428090415808605, 1.9428090415832664 1.471404520788626, 1.4714045207910316 0.9999999999987971, 1.0000000000012028 1.4714045207910318))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.5285954792065625 0.0571909584191395, 0.9999999999987972 0.5285954792089682, 1.471404520788626 0.0571909584167336, 0.9999999999963913 -0.4142135623730951, 0.5285954792065625 0.0571909584191395))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((0.9999999999987972 0.5285954792089682, 1.4714045207910316 0.9999999999987971, 1.9428090415808608 0.5285954792065625, 1.471404520788626 0.0571909584167336, 0.9999999999987972 0.5285954792089682))", rs.getObject(1));
+        rs.next();
+        assertGeometryBarelyEquals("POLYGON ((1.4714045207910316 0.9999999999987971, 1.9428090415832664 1.471404520788626, 2.414213562373095 0.9999999999963913, 1.9428090415808608 0.5285954792065625, 1.4714045207910316 0.9999999999987971))", rs.getObject(1));
+        rs.close();
+        st.execute("DROP TABLE grid;");
+    }
+
     @Test
     public void testST_MakeGridFromGeometryLatLon1() throws Exception {
         Envelope env = new Envelope(0.0, 0.008983152841195214, 0.0, 0.008983152841195214);
@@ -697,7 +817,7 @@ public class CreateFunctionTest {
 
     @Test
     public void testST_MakeGridColumnsRows() throws Exception {
-        st.execute("drop table if exists grid; CREATE TABLE grid AS SELECT * FROM st_makegrid('POLYGON((0 0, 2 0, 2 2, 0 0 ))'::GEOMETRY, 2, 2, false, true);");
+        st.execute("drop table if exists grid; CREATE TABLE grid AS SELECT * FROM st_makegrid('POLYGON((0 0, 2 0, 2 2, 0 0 ))'::GEOMETRY, 2, 2, false, true, 0);");
         ResultSet rs = st.executeQuery("select count(*) from grid;");
         rs.next();
         assertEquals(rs.getInt(1), 4);
@@ -717,7 +837,7 @@ public class CreateFunctionTest {
 
     @Test
     public void testST_MakeGridColumnsRows2() throws Exception {
-        st.execute("drop table if exists grid; CREATE TABLE grid AS SELECT * FROM st_makegrid('POLYGON((0 0, 2 0, 2 2, 0 0 ))'::GEOMETRY, 1, 2, false, true);");
+        st.execute("drop table if exists grid; CREATE TABLE grid AS SELECT * FROM st_makegrid('POLYGON((0 0, 2 0, 2 2, 0 0 ))'::GEOMETRY, 1, 2, false, true, 0);");
         ResultSet rs = st.executeQuery("select count(*) from grid;");
         rs.next();
         assertEquals(rs.getInt(1), 2);
@@ -735,7 +855,7 @@ public class CreateFunctionTest {
     @Test
     public void testST_MakeGridColumnsRows3() throws Exception {
         st.execute("drop table if exists grid; CREATE TABLE grid AS SELECT * FROM " +
-                "st_makegrid('POLYGON((0 0, 2 0, 2 2, 0 0 ))'::GEOMETRY, 2, 1, false, true);");
+                "st_makegrid('POLYGON((0 0, 2 0, 2 2, 0 0 ))'::GEOMETRY, 2, 1, false, true, 0);");
         ResultSet rs = st.executeQuery("select count(*) from grid;");
         rs.next();
         assertEquals(rs.getInt(1), 2);

--- a/h2gis-functions/src/test/java/org/h2gis/functions/spatial/create/CreateFunctionTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/spatial/create/CreateFunctionTest.java
@@ -34,6 +34,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Locale;
 
 import static org.h2gis.unitTest.GeometryAsserts.assertGeometryBarelyEquals;
 import static org.h2gis.unitTest.GeometryAsserts.assertGeometryEquals;
@@ -464,7 +465,7 @@ public class CreateFunctionTest {
         Envelope outPutEnv = GeographyUtilities.createEnvelope(new Coordinate(0.0, 0.0), 1000, 1000);
         assertEquals(env, outPutEnv);
         Geometry geom = FACTORY.toGeometry(outPutEnv);
-        st.execute(String.format("drop table if exists grid; CREATE TABLE grid AS SELECT * FROM st_makegrid('srid=%s;%s'::GEOMETRY, 1000, 1000);", "4326", geom.toString()));
+        st.execute(String.format(Locale.ROOT ,"drop table if exists grid; CREATE TABLE grid AS SELECT * FROM st_makegrid('srid=%s;%s'::GEOMETRY, 1000, 1000);", "4326", geom.toString()));
         ResultSet rs = st.executeQuery("select count(*) from grid;");
         rs.next();
         assertEquals(rs.getInt(1), 1);
@@ -482,7 +483,7 @@ public class CreateFunctionTest {
         Envelope outPutEnv = GeographyUtilities.createEnvelope(new Coordinate(0.0, 0.0), 100, 100);
         assertEquals(env, outPutEnv);
         Geometry geom = FACTORY.toGeometry(outPutEnv);
-        st.execute(String.format("drop table if exists grid; CREATE TABLE grid AS SELECT * FROM st_makegrid('srid=%s;%s'::GEOMETRY, 1000, 1000);", "4326", geom.toString()));
+        st.execute(String.format(Locale.ROOT, "drop table if exists grid; CREATE TABLE grid AS SELECT * FROM st_makegrid('srid=%s;%s'::GEOMETRY, 1000, 1000);", "4326", geom.toString()));
         ResultSet rs = st.executeQuery("select count(*) from grid;");
         rs.next();
         assertEquals(rs.getInt(1), 1);
@@ -500,7 +501,7 @@ public class CreateFunctionTest {
         Envelope outPutEnv = GeographyUtilities.createEnvelope(new Coordinate(0.0, 0.0), 1000, 1000);
         assertEquals(env, outPutEnv);
         Geometry geom = FACTORY.toGeometry(outPutEnv);
-        st.execute(String.format("drop table if exists grid; CREATE TABLE grid AS SELECT * FROM st_makegrid('srid=%s;%s'::GEOMETRY, 100, 100);", "4326", geom.toString()));
+        st.execute(String.format(Locale.ROOT, "drop table if exists grid; CREATE TABLE grid AS SELECT * FROM st_makegrid('srid=%s;%s'::GEOMETRY, 100, 100);", "4326", geom.toString()));
         ResultSet rs = st.executeQuery("select count(*) from grid;");
         rs.next();
         assertEquals(rs.getInt(1), 100);

--- a/h2gis-utilities/src/main/java/org/h2gis/utilities/GeometryTableUtilities.java
+++ b/h2gis-utilities/src/main/java/org/h2gis/utilities/GeometryTableUtilities.java
@@ -29,6 +29,7 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 
 import static org.h2gis.utilities.dbtypes.DBTypes.*;
 import static org.h2gis.utilities.dbtypes.DBUtils.getDBType;
@@ -87,7 +88,7 @@ public class GeometryTableUtilities {
                 }
             }
         }
-        throw new SQLException(String.format("The table %s does not contain a geometry field", geometryTable));
+        throw new SQLException(String.format(Locale.ROOT, "The table %s does not contain a geometry field", geometryTable));
         }
         throw new SQLException("Database not supported");
     }
@@ -1076,7 +1077,7 @@ public class GeometryTableUtilities {
             throws SQLException {
         if (geometryField != null && !geometryField.isEmpty()) {
             PreparedStatement geomStatement = prepareInformationSchemaStatement(connection, catalog, schema, table,
-                    "geometry_columns", String.format(" and F_GEOMETRY_COLUMN ='%s'", geometryField));
+                    "geometry_columns", String.format(Locale.ROOT, " and F_GEOMETRY_COLUMN ='%s'", geometryField));
             return geomStatement.executeQuery();
         }
         throw new SQLException("Unable to get geometry metadata from a null or empty column name");

--- a/h2gis-utilities/src/main/java/org/h2gis/utilities/JDBCUtilities.java
+++ b/h2gis-utilities/src/main/java/org/h2gis/utilities/JDBCUtilities.java
@@ -330,7 +330,7 @@ public class JDBCUtilities {
         Statement st = connection.createStatement();
         int rowCount = 0;
         try {
-            ResultSet rs = st.executeQuery(String.format("select count(*) rowcount from %s", tableName));
+            ResultSet rs = st.executeQuery(String.format(Locale.ROOT, "select count(*) rowcount from %s", tableName));
             try {
                 if (rs.next()) {
                     rowCount = rs.getInt(1);

--- a/h2gis-utilities/src/main/java/org/h2gis/utilities/Tuple.java
+++ b/h2gis-utilities/src/main/java/org/h2gis/utilities/Tuple.java
@@ -19,6 +19,8 @@
  */
 package org.h2gis.utilities;
 
+import java.util.Locale;
+
 /**
  * Basic tuple class
  * @author Erwan Bocher
@@ -46,7 +48,7 @@ public class Tuple<T, U> {
 
     @Override
     public String toString() {
-        return String.format("(%s, %s)", _1, _2);
+        return String.format(Locale.ROOT, "(%s, %s)", _1, _2);
     }
 
 }


### PR DESCRIPTION
Added a new parameter, "angle" in radians, to ST_Make_Grid to allow grid rotation.

There are now 4 signatures for ST_MakeGrid.

ST_MakeGrid(Value, deltaX, deltaY);
ST_MakeGrid(Value, deltaX, deltaY, ValueAngleOrder);
ST_MakeGrid(Value, deltaX, deltaY, upperOrder, angle);
ST_MakeGrid(Value, deltaX, deltaY, upperOrder, isColumnsRowsMeasure, angle);

With :
value could be the name of a table or a geometry.
deltaX a double, the X cell size.
deltaY a double, the Y cell size.
valueAngleOrder could be the boolean to indicate the start from the upper left corner or the angle in rotation in radian.
upperOrder, a boolean, to start the cell from the upper left corner.
angle, a double, the rotation in radian.
isColumnsRowsMeasure, a boolean to indicate that deltaX and deltaY refer to the number of columns and rows.

In order to perform the rotation, the reset function of GridRowSet was modified to rotate the envelope and the readRow funnction of GridRowset was modified to rotate the grid.

To verify the new parameter, 7 tests have been added.

testST_MakeGridFromGeometryWithAngle1 : test grid rotation with 1 polygon and 360 degrees
testST_MakeGridFromGeometryWithAngle2 : test grid rotation with 1 polygon and 180 degrees
testST_MakeGridFromGeometryWithAngle3 : test grid rotation 45 degrees
testST_MakeGridFromGeometryWithAngle4 : test grid rotation with upperOrder true and 90 degrees
testST_MakeGridFromGeometryWithAngle5 : test grid rotation with isColumnsRowsMeasure true and 45 degrees
testST_MakeGridFromGeometryWithAngleNegative : test grid rotation with - 45 degrees
testST_MakeGridFromSubqueryWithAngle : test grid rotation with a subquery and a angle of 45 degrees